### PR TITLE
Fixed a small bug which lead to errors being detected where there are…

### DIFF
--- a/src/nl/esciencecenter/xenon/adaptors/scripting/RemoteCommandRunner.java
+++ b/src/nl/esciencecenter/xenon/adaptors/scripting/RemoteCommandRunner.java
@@ -119,7 +119,7 @@ public class RemoteCommandRunner {
     }
 
     public boolean success() {
-        return exitCode == 0 && error.isEmpty();
+        return exitCode == 0;
     }
 
     public String toString() {


### PR DESCRIPTION
stderror can be non-empty even when there are no errors caused by the remotecommand. For example, on Cartesius loading certain modules (as part of your bashrc) echos the name of the module to stderror. Leading the succes() method to declare that something went wrong incorrectly.