### PR TITLE
Run Docker integration tests with gradle check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ addons:
   apt_packages:
     - pandoc
     - texlive
-script: ./gradlew check -xintegrationTest
+script: ./gradlew check -xdockerTest --continue

--- a/build-common.gradle
+++ b/build-common.gradle
@@ -195,8 +195,6 @@ task integrationTest(type: Test) {
     outputs.upToDateWhen { false }
 }
 
-//Ensure that the check task fails the build if there are failing integration tests.
-check.dependsOn integrationTest
 //Ensure that our unit tests are run before our integration tests
 integrationTest.mustRunAfter test
 
@@ -289,3 +287,34 @@ task wrapper(type: Wrapper) {
     group 'Build Setup'
     gradleVersion = '2.7'
 }
+
+//     DOCKER
+// ==============
+
+task checkDockerComposePresence(type: Exec) {
+    executable 'docker-compose'
+    args = ['-v']
+    standardOutput = new ByteArrayOutputStream()
+}
+
+class DockerCompose extends Exec {
+    def DockerCompose() {
+        workingDir 'src/integrationTest/docker'
+        executable 'docker-compose'
+        dependsOn project.tasks.checkDockerComposePresence
+    }
+}
+
+task dockerKill(type: DockerCompose) {
+    args = ['kill']
+}
+
+task dockerCleanup(type: DockerCompose, dependsOn: dockerKill) {
+    args = ['rm', '-f']
+}
+
+task dockerTest(type: DockerCompose) {
+    args = ['run', '--rm', 'xenon-test']
+}
+dockerTest.finalizedBy dockerCleanup
+check.dependsOn dockerTest

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,11 @@ jacocoTestReport.description = 'Generate coverage report of unit tests'
 jacocoTestReport.group = 'Code coverage reporting'
 
 task prepareIntegrationTest << {
-    file('xenon.test.properties').withReader { reader ->
+    def xenonPropertiesFile = 'xenon.test.properties'
+    if (project.hasProperty('xenon.test.properties')) {
+        xenonPropertiesFile = project.get('xenon.test.properties')
+    }
+    file(xenonPropertiesFile).withReader { reader ->
         def userProps = new Properties()
         userProps.load(reader)
 

--- a/src/integrationTest/docker/Dockerfile
+++ b/src/integrationTest/docker/Dockerfile
@@ -24,4 +24,4 @@ VOLUME ["/code"]
 WORKDIR /code
 
 ENTRYPOINT ["/bin/run-tests.sh"]
-CMD ["./gradlew", "check"]
+CMD ["./gradlew", "-Pxenon.test.properties=src/integrationTest/docker/xenon.test.properties.docker", "check" "integrationTest", "-xdockerTest"]


### PR DESCRIPTION
build-common.gradle now includes a docker section for starting
docker, running the integration tests in docker and then killing
docker again and cleaning up its files. The integrationTest
is no longer part of gradle check, because it is not expected to
succeed without the help of docker. gradle check now takes about
20 minutes.