### PR TITLE
Use output from URI to create local filesystem

### DIFF
--- a/src/examples/java/nl/esciencecenter/xenon/examples/files/FileExists.java
+++ b/src/examples/java/nl/esciencecenter/xenon/examples/files/FileExists.java
@@ -43,7 +43,7 @@ public class FileExists {
     public static void main(String[] args) {
 
         if (args.length != 1) {
-            System.out.println("Example requires a URI as a parameter!");
+            System.out.println("Example requires a URI as a parameter");
             System.exit(1);
         }
 
@@ -79,9 +79,12 @@ public class FileExists {
             // Finally, we end Xenon to release all resources 
             XenonFactory.endXenon(xenon);
 
-        } catch (URISyntaxException | XenonException e) {
-            System.out.println("FileExists example failed: " + e.getMessage());
-            e.printStackTrace();
+        } catch (URISyntaxException ex) {
+            System.out.println("Provided URI was invalid (remember to add a scheme, e.g. file://): " + ex.getMessage());
+            ex.printStackTrace();
+        } catch (XenonException ex) {
+            System.out.println("FileExists example failed: " + ex.getMessage());
+            ex.printStackTrace();
         }
     }
 }

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/local/LocalFileAdaptorTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/local/LocalFileAdaptorTest.java
@@ -16,12 +16,16 @@
 
 package nl.esciencecenter.xenon.adaptors.local;
 
+import static org.junit.Assert.assertEquals;
+
 import nl.esciencecenter.xenon.InvalidLocationException;
 import nl.esciencecenter.xenon.adaptors.GenericFileAdaptorTestParent;
+import nl.esciencecenter.xenon.files.FileSystem;
 import nl.esciencecenter.xenon.util.Utils;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * @author Jason Maassen <J.Maassen@esciencecenter.nl>
@@ -39,48 +43,86 @@ public class LocalFileAdaptorTest extends GenericFileAdaptorTestParent {
         GenericFileAdaptorTestParent.cleanupClass();
     }
     
-    @org.junit.Test(expected = InvalidLocationException.class)
+    @Test
     public void test_checkLocation_null() throws Exception {
         LocalFiles.checkFileLocation(null);
     }
 
-    @org.junit.Test(expected = InvalidLocationException.class)
+    @Test
     public void test_checkLocation_empty() throws Exception {
         LocalFiles.checkFileLocation("");
     }
 
-    @org.junit.Test
+    @Test
     public void test_checkLocation_linuxRoot() throws Exception {
         if (Utils.isLinux() || Utils.isOSX()) { 
             LocalFiles.checkFileLocation("/");
         }
     }
 
-    @org.junit.Test
+    @Test
     public void test_checkLocation_windowsRoot() throws Exception {
         if (Utils.isWindows()) { 
             LocalFiles.checkFileLocation("C:");
         }
     }
 
-    @org.junit.Test(expected = InvalidLocationException.class)
+    @Test(expected = InvalidLocationException.class)
     public void test_checkLocation_wrong() throws Exception {
         LocalFiles.checkFileLocation("ABC");
     }
 
-    @org.junit.Test(expected = InvalidLocationException.class)
+    @Test(expected = InvalidLocationException.class)
     public void test_checkLocation_withPath() throws Exception {
         LocalFiles.checkFileLocation("/aap");
     }
 
-    @org.junit.Test(expected = InvalidLocationException.class)
+    @Test(expected = InvalidLocationException.class)
     public void test_checkLocation_withWindowsPath() throws Exception {
         LocalFiles.checkFileLocation("C:/aap");
     }
     
-    @org.junit.Test(expected = InvalidLocationException.class)
+    @Test(expected = InvalidLocationException.class)
     public void test_checkLocation_withWindowsPath2() throws Exception {
         LocalFiles.checkFileLocation("C:\\aap");
     }
 
+    @Test
+    public void test_newFileSystem_nullLocation() throws Exception {
+        FileSystem fs = files.newFileSystem("local", null, credentials.getDefaultCredential("local"), null);
+        if (Utils.isWindows()) {
+            assertEquals("", fs.getLocation());
+        } else {
+            assertEquals("/", fs.getLocation());
+        }
+    }
+
+    @Test
+    public void test_newFileSystem_emptyLocation() throws Exception {
+        FileSystem fs = files.newFileSystem("local", "", credentials.getDefaultCredential("local"), null);
+        if (Utils.isWindows()) {
+            assertEquals("", fs.getLocation());
+        } else {
+            assertEquals("/", fs.getLocation());
+        }
+    }
+
+    @Test
+    public void test_newFileSystem_windowsNetworkLocation() throws Exception {
+        if (!Utils.isWindows()) {
+            return;
+        }
+
+        FileSystem fs = files.newFileSystem("local", "mynetwork", credentials.getDefaultCredential("local"), null);
+        assertEquals("mynetwork", fs.getLocation());
+    }
+
+    @Test(expected = InvalidLocationException.class)
+    public void test_newFileSystem_linuxNetworkLocation_throws() throws Exception {
+        if (Utils.isWindows()) {
+            throw new InvalidLocationException(null, null);
+        }
+
+        files.newFileSystem("local", "mynetwork", credentials.getDefaultCredential("local"), null);
+    }
 }

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpFiles.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpFiles.java
@@ -29,6 +29,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import nl.esciencecenter.xenon.InvalidCredentialException;
+import nl.esciencecenter.xenon.InvalidLocationException;
+import nl.esciencecenter.xenon.InvalidPropertyException;
+import nl.esciencecenter.xenon.InvalidSchemeException;
+import nl.esciencecenter.xenon.UnknownPropertyException;
 import nl.esciencecenter.xenon.XenonException;
 import nl.esciencecenter.xenon.XenonPropertyDescription.Component;
 import nl.esciencecenter.xenon.adaptors.ssh.SshAdaptor;
@@ -117,12 +122,12 @@ public class FtpFiles implements Files {
 
     @Override
     public FileSystem newFileSystem(String scheme, String location, Credential credential, Map<String, String> properties)
-            throws XenonException {
+            throws InvalidCredentialException, InvalidLocationException, UnknownPropertyException, InvalidPropertyException, XenonException {
         LOGGER.debug("newFileSystem scheme = {} location = {} credential = {} properties = {}", scheme, location, credential,
                 properties);
 
         if (credential == null) {
-            throw new XenonException(adaptor.getName(), "Credentials was null.");
+            throw new InvalidCredentialException(adaptor.getName(), "Credentials was null.");
         }
 
         XenonProperties xenonProperties = new XenonProperties(adaptor.getSupportedProperties(Component.FILESYSTEM), properties);

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalFiles.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalFiles.java
@@ -114,14 +114,10 @@ public class LocalFiles implements nl.esciencecenter.xenon.files.Files {
      *          if the location is invalid.                   
      */
     static void checkFileLocation(String location) throws InvalidLocationException {
-        if (location == null) {
-            throw new InvalidLocationException(LocalAdaptor.ADAPTOR_NAME, "Location must contain a file system root! (not null)");
-        }
-    
-        if (Utils.isLocalRoot(location)) { 
+        if (location == null || location.isEmpty() || Utils.isLocalRoot(location)) {
             return;
         }
-        
+
         throw new InvalidLocationException(LocalAdaptor.ADAPTOR_NAME, "Location must only contain a file system root! (not " + location + ")");
     }
     
@@ -298,16 +294,15 @@ public class LocalFiles implements nl.esciencecenter.xenon.files.Files {
     @Override
     public FileSystem newFileSystem(String scheme, String location, Credential credential, Map<String, String> properties) 
             throws XenonException {
-
         checkFileLocation(location);
-        
+
         localAdaptor.checkCredential(credential);
 
         XenonProperties p = new XenonProperties(localAdaptor.getSupportedProperties(Component.FILESYSTEM), properties);
 
         String root = Utils.getLocalRoot(location);
-        RelativePath relativePath = Utils.getRelativePath(location, root);
-        
+        RelativePath relativePath = new RelativePath(root).relativize(new RelativePath(location));
+
         return new FileSystemImplementation(LocalAdaptor.ADAPTOR_NAME, "localfs-" + getNextFsID(), scheme, root,  
                 relativePath, credential, p);
     }

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalFiles.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalFiles.java
@@ -89,7 +89,6 @@ public class LocalFiles implements nl.esciencecenter.xenon.files.Files {
      *  
      */
     private void checkParent(Path path) throws XenonException {
-        
         RelativePath parentName = path.getRelativePath().getParent();
         
         if (parentName == null) { 
@@ -144,7 +143,6 @@ public class LocalFiles implements nl.esciencecenter.xenon.files.Files {
      */
     @Override
     public void move(Path source, Path target) throws XenonException {
-
         if (!exists(source)) {
             throw new NoSuchPathException(LocalAdaptor.ADAPTOR_NAME, "Source " + source + " does not exist!");
         }
@@ -167,7 +165,6 @@ public class LocalFiles implements nl.esciencecenter.xenon.files.Files {
 
     @Override
     public Path readSymbolicLink(Path link) throws XenonException {
-
         try {
             java.nio.file.Path path = LocalUtils.javaPath(link);
             java.nio.file.Path target = Files.readSymbolicLink(path);
@@ -186,7 +183,6 @@ public class LocalFiles implements nl.esciencecenter.xenon.files.Files {
 
     @Override
     public DirectoryStream<Path> newDirectoryStream(Path dir, DirectoryStream.Filter filter) throws XenonException {
-
         FileAttributes att = getAttributes(dir);
 
         if (!att.isDirectory()) {
@@ -342,7 +338,6 @@ public class LocalFiles implements nl.esciencecenter.xenon.files.Files {
 
     @Override
     public void createDirectory(Path dir) throws XenonException {
-
         if (exists(dir)) {
             throw new PathAlreadyExistsException(LocalAdaptor.ADAPTOR_NAME, "Directory " + dir + " already exists!");
         }

--- a/src/main/java/nl/esciencecenter/xenon/files/Files.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/Files.java
@@ -20,6 +20,11 @@ import java.io.OutputStream;
 import java.util.Map;
 import java.util.Set;
 
+import nl.esciencecenter.xenon.InvalidCredentialException;
+import nl.esciencecenter.xenon.InvalidLocationException;
+import nl.esciencecenter.xenon.InvalidPropertyException;
+import nl.esciencecenter.xenon.InvalidSchemeException;
+import nl.esciencecenter.xenon.UnknownPropertyException;
 import nl.esciencecenter.xenon.XenonException;
 import nl.esciencecenter.xenon.credentials.Credential;
 
@@ -64,7 +69,7 @@ public interface Files {
      *             If the creation of the FileSystem failed.
      */
     FileSystem newFileSystem(String scheme, String location, Credential credential, Map<String, String> properties) 
-            throws XenonException;
+            throws UnknownPropertyException, InvalidPropertyException, InvalidSchemeException, InvalidLocationException, InvalidCredentialException, XenonException;
         
     /**
      * Create a new Path that represents a (possibly non existing) location on <code>filesystem.</code>
@@ -87,12 +92,8 @@ public interface Files {
      * @param filesystem
      *            the FileSystem to close.
      * 
-     * @throws CannotClosedException
-     *             If the FileSystem cannot be closed (for example a local FileSystem).
      * @throws XenonException
-     *             If the FileSystem failed to close.
-     * @throws XenonException
-     *             If an I/O error occurred.
+     *             If the FileSystem failed to close or if an I/O error occurred.
      */
     void close(FileSystem filesystem) throws XenonException;
 
@@ -103,9 +104,7 @@ public interface Files {
      *            the FileSystem to test.
      * 
      * @throws XenonException
-     *             If the test failed.
-     * @throws XenonException
-     *             If an I/O error occurred.
+     *             If the test failed or an I/O error occurred.
      */
     boolean isOpen(FileSystem filesystem) throws XenonException;
 
@@ -172,6 +171,8 @@ public interface Files {
      *            the existing source file or link.
      * @param target
      *            the target path.
+     * @param options
+     *            options for the copy operation.
      * @return a {@link CopyStatus} if the copy is asynchronous or <code>null</code> if it is blocking.
      * 
      * @throws NoSuchPathException

--- a/src/main/java/nl/esciencecenter/xenon/files/Files.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/Files.java
@@ -41,7 +41,7 @@ public interface Files {
      * @param scheme
      *            the scheme to use to access the FileSystem.
      * @param location
-     *            the location of the FileSystem.
+     *            the location of the FileSystem, may be null for a local file system.
      * @param credential
      *            the Credentials to use to get access to the FileSystem.
      * @param properties

--- a/src/main/java/nl/esciencecenter/xenon/files/RelativePath.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/RelativePath.java
@@ -45,7 +45,7 @@ public class RelativePath implements Iterable<RelativePath> {
     /** Estimate of path element String length. */
     private final int PATH_ELEMENT_LENGTH = 25;
 
-    class RelativePathIterator implements Iterator<RelativePath> {
+    private class RelativePathIterator implements Iterator<RelativePath> {
         private int index = 1;
 
         @Override

--- a/src/main/java/nl/esciencecenter/xenon/util/Utils.java
+++ b/src/main/java/nl/esciencecenter/xenon/util/Utils.java
@@ -414,7 +414,6 @@ public final class Utils {
      * @return If <code>root</code> only contains a valid Windows root element.
      */
     public static boolean isWindowsRoot(String root) {
-
         if (root == null) {
             return false;
         }
@@ -471,7 +470,6 @@ public final class Utils {
      * @return If <code>root</code> only contains a valid OSX root element.
      */
     public static boolean isLocalRoot(String root) {
-
         if (isWindows()) {
             return isWindowsRoot(root);
         }
@@ -487,7 +485,6 @@ public final class Utils {
      * @return If the provide path starts with a valid Linux root.
      */
     public static boolean startsWithLinuxRoot(String path) {
-
         if (path == null) {
             return false;
         }
@@ -503,7 +500,6 @@ public final class Utils {
      * @return If the provide path starts with a valid Windows root.
      */
     public static boolean startWithWindowsRoot(String path) {
-
         if (path == null) {
             return false;
         }
@@ -538,7 +534,6 @@ public final class Utils {
      *             If the <code>path</code> does not start with <code>root</code>.
      */
     public static RelativePath getRelativePath(String path, String root) throws XenonException {
-
         if (!path.toUpperCase(Locale.getDefault()).startsWith(root.toUpperCase(Locale.getDefault()))) {
             throw new XenonException(NAME, "Path does not start with root: " + path + " " + root);
         }
@@ -592,9 +587,7 @@ public final class Utils {
      * @return a <code>Path</code> that represents the current working directory.
      *
      * @throws XenonException
-     *             If an I/O error occurred
-     * @throws XenonException
-     *             If the creation of the FileSystem failed.
+     *             If an I/O error occurred or if the creation of the FileSystem failed.
      */
     public static Path getLocalCWD(Files files) throws XenonException {
         return fromLocalPath(files, getCWD());
@@ -669,7 +662,6 @@ public final class Utils {
      *             if an I/O error occurs when reading or writing
      */
     public static long copy(Files files, InputStream in, Path target, boolean truncate) throws XenonException {
-
         long bytes = 0;
         OutputStream out = null;
 
@@ -757,7 +749,6 @@ public final class Utils {
      *             if an I/O error occurs while opening or writing the file.
      */
     public static BufferedWriter newBufferedWriter(Files files, Path target, Charset cs, boolean truncate) throws XenonException {
-
         OutputStream out = files.newOutputStream(target, openOptionsForWrite(truncate));
         return new BufferedWriter(new OutputStreamWriter(out, cs));
     }
@@ -797,7 +788,6 @@ public final class Utils {
      *             if an I/O error occurs while opening or reading the file.
      */
     public static String readToString(Files files, Path source, Charset cs) throws XenonException {
-
         InputStream in = null;
 
         try {
@@ -826,7 +816,6 @@ public final class Utils {
      *             if an I/O error occurs while opening or reading the file.
      */
     public static List<String> readAllLines(Files files, Path source, Charset cs) throws XenonException {
-
         InputStream in = null;
 
         try {

--- a/src/main/java/nl/esciencecenter/xenon/util/Utils.java
+++ b/src/main/java/nl/esciencecenter/xenon/util/Utils.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import nl.esciencecenter.xenon.InvalidLocationException;
 import nl.esciencecenter.xenon.XenonException;
 import nl.esciencecenter.xenon.credentials.Credential;
 import nl.esciencecenter.xenon.files.CopyOption;
@@ -347,20 +348,29 @@ public final class Utils {
      *             If the provided <code>path</code> is not absolute, or does not contain a locally valid root.
      */
     public static String getLocalRoot(String path) throws XenonException {
-
         if (isWindows()) {
-            if (path != null && path.length() >= 2 && (path.charAt(1) == ':') && Character.isLetter(path.charAt(0))) {
+            if (path == null || path.isEmpty()) {
+                return "";
+            }
+            if (!path.contains("/") && !path.contains("\\")) {
+                // Windows URS, network drive
+                return path;
+            }
+            if (path.charAt(0) == '/') {
+                path = path.substring(1);
+            }
+            if (path.length() >= 2 && (path.charAt(1) == ':') && Character.isLetter(path.charAt(0))) {
                 return path.substring(0, 2).toUpperCase();
             }
 
-            throw new XenonException(NAME, "Path is not absolute! " + path);
+            throw new InvalidLocationException(NAME, "Path does not include drive name! " + path);
         }
 
-        if (path != null && path.length() >= 1 && (path.charAt(0) == '/')) {
+        if (path == null || path.isEmpty() || (path.length() >= 1 && path.charAt(0) == '/')) {
             return "/";
         }
 
-        throw new XenonException(NAME, "Path is not absolute! " + path);
+        throw new InvalidLocationException(NAME, "Path is not absolute! " + path);
     }
 
     /**


### PR DESCRIPTION
Solves #293. Main difference: aside from `/` and `C:`, LocalFiles.newFilesystem() now also accepts null, an empty string, and a Windows network drive name (no slashes/backslashes) as a root location. This brings it in line with URI parsing.