### PR TITLE
Travis docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ matrix:
   include:
     - jdk: oraclejdk7
       env:
-        - GRADLE_BUILD_TASKS="assemble"
-        - GRADLE_SCRIPT_TASKS="check"
-    - jdk: openjdk7
-      env:
         - GRADLE_BUILD_TASKS="assemble dockerBuild"
         - GRADLE_SCRIPT_TASKS="check dockerIntegrationTest"
+    - jdk: openjdk7
+      env:
+        - GRADLE_BUILD_TASKS="assemble"
+        - GRADLE_SCRIPT_TASKS="check"
     - jdk: oraclejdk8
       env:
         - GRADLE_BUILD_TASKS="assemble"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
         - GRADLE_SCRIPT_TASKS=check
     - jdk: openjdk7
       env:
-        - GRADLE_BUILD_TASKS=assemble dockerBuild dockerTestCache
+        - GRADLE_BUILD_TASKS=assemble dockerBuild
         - GRADLE_SCRIPT_TASKS=check dockerIntegrationTest
     - jdk: oraclejdk8
       env:
@@ -36,6 +36,7 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/1.4.2/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
+  - touch .docker-test-cache-set
 
 install:
   - gradle $GRADLE_BUILD_TASKS

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - jdk: oraclejdk7
       env:
         - GRADLE_BUILD_TASKS="assemble dockerBuild"
-        - GRADLE_SCRIPT_TASKS="clean dockerIntegrationTest check"
+        - GRADLE_SCRIPT_TASKS="check dockerIntegrationTest"
       sudo: true
       services:
         - docker
@@ -40,7 +40,7 @@ before_install:
   - touch .docker-test-cache-set
 
 install:
-  - gradle $GRADLE_BUILD_TASKS
+  - gradle $GRADLE_BUILD_TASKS -Ddocker.uid=$UID
 
 script:
-  - gradle $GRADLE_SCRIPT_TASKS
+  - gradle $GRADLE_SCRIPT_TASKS -Ddocker.uid=$UID

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
   apt_packages:
     - pandoc
     - texlive
+    - lmodern
 
 before_install:
   - curl -L https://github.com/docker/compose/releases/download/1.4.2/docker-compose-`uname -s`-`uname -m` > docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - jdk: oraclejdk7
       env:
         - GRADLE_BUILD_TASKS="assemble dockerBuild"
-        - GRADLE_SCRIPT_TASKS="check dockerIntegrationTest"
+        - GRADLE_SCRIPT_TASKS="clean dockerIntegrationTest check"
     - jdk: openjdk7
       env:
         - GRADLE_BUILD_TASKS="assemble"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,22 @@
 language: java
 
-jdk:
-  - oraclejdk7
-  - openjdk7
-  - oraclejdk8
-# Stop when one of the Java versions do not work
 matrix:
+  # Only do docker integration tests with OpenJDK 7: the docker
+  # tests are not affected by JDK on host system.
+  include:
+    - jdk: oraclejdk7
+      env:
+        - GRADLE_BUILD_TASKS=assemble
+        - GRADLE_SCRIPT_TASKS=check
+    - jdk: openjdk7
+      env:
+        - GRADLE_BUILD_TASKS=assemble dockerBuild dockerTestCache
+        - GRADLE_SCRIPT_TASKS=check dockerIntegrationTest
+    - jdk: oraclejdk8
+      env:
+        - GRADLE_BUILD_TASKS=assemble
+        - GRADLE_SCRIPT_TASKS=check
+  # Stop when one of the Java versions do not work
   fast_finish: true
 
 sudo: required
@@ -13,19 +24,21 @@ sudo: required
 services:
   - docker
 
+# Install documentation dependencies
 addons:
   apt_packages:
     - pandoc
     - texlive
     - lmodern
 
+# Install Docker compose
 before_install:
   - curl -L https://github.com/docker/compose/releases/download/1.4.2/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
 
 install:
-  - gradle assemble dockerBuild dockerTestCache
+  - gradle $GRADLE_BUILD_TASKS
 
 script:
-  - gradle check dockerIntegrationTest
+  - gradle $GRADLE_SCRIPT_TASKS

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   - touch .docker-test-cache-set
 
 install:
-  - gradle $GRADLE_BUILD_TASKS -Ddocker.uid=$UID
+  - gradle $GRADLE_BUILD_TASKS -Pdocker.uid=$UID
 
 script:
-  - gradle $GRADLE_SCRIPT_TASKS -Ddocker.uid=$UID
+  - gradle $GRADLE_SCRIPT_TASKS -Pdocker.uid=$UID

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,16 @@ matrix:
   include:
     - jdk: oraclejdk7
       env:
-        - GRADLE_BUILD_TASKS=assemble
-        - GRADLE_SCRIPT_TASKS=check
+        - GRADLE_BUILD_TASKS="assemble"
+        - GRADLE_SCRIPT_TASKS="check"
     - jdk: openjdk7
       env:
-        - GRADLE_BUILD_TASKS=assemble dockerBuild
-        - GRADLE_SCRIPT_TASKS=check dockerIntegrationTest
+        - GRADLE_BUILD_TASKS="assemble dockerBuild"
+        - GRADLE_SCRIPT_TASKS="check dockerIntegrationTest"
     - jdk: oraclejdk8
       env:
-        - GRADLE_BUILD_TASKS=assemble
-        - GRADLE_SCRIPT_TASKS=check
+        - GRADLE_BUILD_TASKS="assemble"
+        - GRADLE_SCRIPT_TASKS="check"
   # Stop when one of the Java versions do not work
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,30 @@
 language: java
+
 jdk:
   - oraclejdk7
   - openjdk7
   - oraclejdk8
-sudo: false
+# Stop when one of the Java versions do not work
+matrix:
+  fast_finish: true
+
+sudo: required
+
+services:
+  - docker
+
 addons:
   apt_packages:
     - pandoc
     - texlive
+
+before_install:
+  - curl -L https://github.com/docker/compose/releases/download/1.4.2/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+
+install:
+  - gradle assemble dockerBuild dockerTestCache
+
+script:
+  - gradle check dockerIntegrationTest

--- a/gradle/docker.gradle
+++ b/gradle/docker.gradle
@@ -72,7 +72,6 @@ task dockerIntegrationTest(type: DockerCompose, dependsOn: 'dockerTestCache') {
         ]
     }
     finalizedBy 'dockerCleanup'
-    mustRunAfter 'test'
 }
 
 //  DOCKER BUILD SETUP


### PR DESCRIPTION
The integration tests now run on Travis CI. See: https://travis-ci.org/NLeSC/Xenon/jobs/86233147
Note: the dockerIntegrationTests run only once, the unit tests are performed three times, one per JDK.