### PR TITLE
Added task to check files for license header.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,14 @@ plugins {
     id 'jacoco'
     // quality
     id 'pmd'
+    // license
+    id 'com.github.hierynomus.license' version '0.12.1'
 }
 
 apply from: 'gradle/common.gradle'
 apply from: 'gradle/integrationTest.gradle'
 apply from: 'gradle/codestyle.gradle'
+apply from: 'gradle/license.gradle'
 
 //  DEPENDENCIES
 // ==============
@@ -107,3 +110,4 @@ bintray {
     }
     publications = ['MyPublication']
 }
+

--- a/config/license/HEADER
+++ b/config/license/HEADER
@@ -1,0 +1,13 @@
+Copyright ${copyright_year} ${copyright_owner}
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/gradle/license.gradle
+++ b/gradle/license.gradle
@@ -1,0 +1,12 @@
+// Checking license 
+// Depends on plugins:
+//   id 'com.github.hierynomus.license' version '0.12.1'
+
+license {
+    ext.copyright_year = 2013
+    ext.copyright_owner = 'Netherlands eScience Center'
+    header rootProject.file('config/license/HEADER')
+    strictCheck true
+    excludes(["**/*.examples", "**/create_symlinks", "**/fixtures/**"])
+}
+

--- a/src/examples/java/nl/esciencecenter/xenon/examples/CreatingXenon.java
+++ b/src/examples/java/nl/esciencecenter/xenon/examples/CreatingXenon.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.examples;
 
 import nl.esciencecenter.xenon.Xenon;

--- a/src/examples/java/nl/esciencecenter/xenon/examples/CreatingXenonWithProperties.java
+++ b/src/examples/java/nl/esciencecenter/xenon/examples/CreatingXenonWithProperties.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.examples;
 
 import java.util.HashMap;

--- a/src/examples/java/nl/esciencecenter/xenon/examples/credentials/CreatingCredential.java
+++ b/src/examples/java/nl/esciencecenter/xenon/examples/credentials/CreatingCredential.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.examples.credentials;
 
 import nl.esciencecenter.xenon.Xenon;

--- a/src/examples/java/nl/esciencecenter/xenon/examples/files/CopyFile.java
+++ b/src/examples/java/nl/esciencecenter/xenon/examples/files/CopyFile.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.examples.files;
 
 import java.net.URI;

--- a/src/examples/java/nl/esciencecenter/xenon/examples/files/CreateFileSystem.java
+++ b/src/examples/java/nl/esciencecenter/xenon/examples/files/CreateFileSystem.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.examples.files;
 
 import java.net.URI;

--- a/src/examples/java/nl/esciencecenter/xenon/examples/files/CreateLocalFileSystem.java
+++ b/src/examples/java/nl/esciencecenter/xenon/examples/files/CreateLocalFileSystem.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.examples.files;
 
 import nl.esciencecenter.xenon.Xenon;

--- a/src/examples/java/nl/esciencecenter/xenon/examples/files/DirectoryListing.java
+++ b/src/examples/java/nl/esciencecenter/xenon/examples/files/DirectoryListing.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.examples.files;
 
 import java.net.URI;

--- a/src/examples/java/nl/esciencecenter/xenon/examples/files/FileExists.java
+++ b/src/examples/java/nl/esciencecenter/xenon/examples/files/FileExists.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.examples.files;
 
 import java.net.URI;

--- a/src/examples/java/nl/esciencecenter/xenon/examples/files/LocalFileExists.java
+++ b/src/examples/java/nl/esciencecenter/xenon/examples/files/LocalFileExists.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.examples.files;
 
 import nl.esciencecenter.xenon.Xenon;

--- a/src/examples/java/nl/esciencecenter/xenon/examples/files/ShowFileAttributes.java
+++ b/src/examples/java/nl/esciencecenter/xenon/examples/files/ShowFileAttributes.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.examples.files;
 
 import java.net.URI;

--- a/src/examples/java/nl/esciencecenter/xenon/examples/jobs/ListJobStatus.java
+++ b/src/examples/java/nl/esciencecenter/xenon/examples/jobs/ListJobStatus.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.examples.jobs;
 
 import java.net.URI;

--- a/src/examples/java/nl/esciencecenter/xenon/examples/jobs/ListJobs.java
+++ b/src/examples/java/nl/esciencecenter/xenon/examples/jobs/ListJobs.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.examples.jobs;
 
 import java.net.URI;

--- a/src/examples/java/nl/esciencecenter/xenon/examples/jobs/ListQueueStatus.java
+++ b/src/examples/java/nl/esciencecenter/xenon/examples/jobs/ListQueueStatus.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.examples.jobs;
 
 import java.net.URI;

--- a/src/examples/java/nl/esciencecenter/xenon/examples/jobs/SubmitBatchJobWithOutput.java
+++ b/src/examples/java/nl/esciencecenter/xenon/examples/jobs/SubmitBatchJobWithOutput.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.examples.jobs;
 
 import java.net.URI;

--- a/src/examples/java/nl/esciencecenter/xenon/examples/jobs/SubmitInteractiveJobWithOutput.java
+++ b/src/examples/java/nl/esciencecenter/xenon/examples/jobs/SubmitInteractiveJobWithOutput.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.examples.jobs;
 
 import java.io.IOException;

--- a/src/examples/java/nl/esciencecenter/xenon/examples/jobs/SubmitSimpleBatchJob.java
+++ b/src/examples/java/nl/esciencecenter/xenon/examples/jobs/SubmitSimpleBatchJob.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.examples.jobs;
 
 import java.net.URI;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/GenericFileAdaptorTestParent.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/GenericFileAdaptorTestParent.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors;
 
 import static org.junit.Assert.assertFalse;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/GenericJobAdaptorTestParent.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/GenericJobAdaptorTestParent.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors;
 
 import static org.junit.Assert.assertEquals;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/GenericScheduleJobTestParent.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/GenericScheduleJobTestParent.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors;
 
 import static org.junit.Assert.assertEquals;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/ftp/FTPFileAdaptorTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/ftp/FTPFileAdaptorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ftp;
 
 import nl.esciencecenter.xenon.adaptors.GenericFileAdaptorTestParent;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineJobAdaptorTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineJobAdaptorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.gridengine;
 
 

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineScheduleJobTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineScheduleJobTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.gridengine;
 
 import static org.junit.Assert.assertEquals;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/local/LocalAdaptorTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/local/LocalAdaptorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.local;
 
 import nl.esciencecenter.xenon.Util;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/local/LocalFileAdaptorTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/local/LocalFileAdaptorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.local;
 
 import static org.junit.Assert.assertEquals;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/local/LocalJobAdaptorTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/local/LocalJobAdaptorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.local;
 
 import nl.esciencecenter.xenon.adaptors.GenericJobAdaptorTestParent;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/local/LocalScheduleJobTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/local/LocalScheduleJobTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.local;
 
 import static org.junit.Assert.assertTrue;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmJobAdaptorTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmJobAdaptorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.slurm;
 
 import static org.junit.Assert.assertEquals;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmScheduleJobTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmScheduleJobTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.slurm;
 
 import static org.junit.Assert.assertEquals;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/ssh/ITSSHCredentialTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/ssh/ITSSHCredentialTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import org.junit.BeforeClass;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/ssh/ITSSHTunnelTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/ssh/ITSSHTunnelTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import java.util.HashMap;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/ssh/SSHFileAdaptorTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/ssh/SSHFileAdaptorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import nl.esciencecenter.xenon.adaptors.GenericFileAdaptorTestParent;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/ssh/SSHJobAdaptorTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/ssh/SSHJobAdaptorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import nl.esciencecenter.xenon.adaptors.GenericJobAdaptorTestParent;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/ssh/SSHScheduleJobTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/ssh/SSHScheduleJobTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import nl.esciencecenter.xenon.adaptors.GenericScheduleJobTestParent;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/torque/TorqueJobAdaptorTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/torque/TorqueJobAdaptorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.torque;
 
 import nl.esciencecenter.xenon.adaptors.GenericJobAdaptorTestParent;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/torque/TorqueScheduleJobTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/torque/TorqueScheduleJobTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.torque;
 
 import nl.esciencecenter.xenon.XenonException;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/engine/credentials/ITCredentialsEngineImplementationTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/engine/credentials/ITCredentialsEngineImplementationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.credentials;
 
 import static org.junit.Assert.assertEquals;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/files/ITInterSchemeCopyTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/files/ITInterSchemeCopyTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.files;
 
 import static org.junit.Assert.assertTrue;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/files/ITInterSchemeMoveTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/files/ITInterSchemeMoveTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.files;
 
 

--- a/src/integrationTest/java/nl/esciencecenter/xenon/jobs/ITJobLocal.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/jobs/ITJobLocal.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.jobs;
 
 import static org.junit.Assert.assertTrue;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/jobs/ITMultiJobTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/jobs/ITMultiJobTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.jobs;
 
 import static org.junit.Assert.assertTrue;

--- a/src/integrationTest/java/nl/esciencecenter/xenon/jobs/SandboxedLocalJobIT.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/jobs/SandboxedLocalJobIT.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/AdaptorStatus.java
+++ b/src/main/java/nl/esciencecenter/xenon/AdaptorStatus.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/IncompatibleVersionException.java
+++ b/src/main/java/nl/esciencecenter/xenon/IncompatibleVersionException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/InvalidCredentialException.java
+++ b/src/main/java/nl/esciencecenter/xenon/InvalidCredentialException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/InvalidLocationException.java
+++ b/src/main/java/nl/esciencecenter/xenon/InvalidLocationException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/InvalidPropertyException.java
+++ b/src/main/java/nl/esciencecenter/xenon/InvalidPropertyException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/InvalidSchemeException.java
+++ b/src/main/java/nl/esciencecenter/xenon/InvalidSchemeException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/NoSuchXenonException.java
+++ b/src/main/java/nl/esciencecenter/xenon/NoSuchXenonException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/UnknownPropertyException.java
+++ b/src/main/java/nl/esciencecenter/xenon/UnknownPropertyException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/Xenon.java
+++ b/src/main/java/nl/esciencecenter/xenon/Xenon.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/XenonException.java
+++ b/src/main/java/nl/esciencecenter/xenon/XenonException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/XenonFactory.java
+++ b/src/main/java/nl/esciencecenter/xenon/XenonFactory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/XenonPropertyDescription.java
+++ b/src/main/java/nl/esciencecenter/xenon/XenonPropertyDescription.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon;
 
 import java.util.Set;

--- a/src/main/java/nl/esciencecenter/xenon/XenonRuntimeException.java
+++ b/src/main/java/nl/esciencecenter/xenon/XenonRuntimeException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpAdaptor.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpAdaptor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpCommand.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpCommand.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.esciencecenter.xenon.adaptors.ftp;
 
 import java.io.IOException;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpCredentials.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpCredentials.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ftp;
 
 import java.util.Map;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpDirectoryAttributeStream.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpDirectoryAttributeStream.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.esciencecenter.xenon.adaptors.ftp;
 
 import java.util.List;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpDirectoryStream.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpDirectoryStream.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.esciencecenter.xenon.adaptors.ftp;
 
 import java.util.List;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpFileAttributes.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpFileAttributes.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.esciencecenter.xenon.adaptors.ftp;
 
 import java.util.HashSet;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpFiles.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpFiles.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpInputStream.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpInputStream.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.esciencecenter.xenon.adaptors.ftp;
 
 import java.io.IOException;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpLocation.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpLocation.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.esciencecenter.xenon.adaptors.ftp;
 
 import nl.esciencecenter.xenon.InvalidLocationException;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpOutputStream.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpOutputStream.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.esciencecenter.xenon.adaptors.ftp;
 
 import java.io.IOException;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpQuery.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpQuery.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.esciencecenter.xenon.adaptors.ftp;
 
 /**

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/generic/DirectoryStreamBase.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/generic/DirectoryStreamBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/generic/Location.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/generic/Location.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.esciencecenter.xenon.adaptors.generic;
 
 import java.net.URI;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineAdaptor.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineAdaptor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineJobScriptGenerator.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineJobScriptGenerator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineSchedulerConnection.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineSchedulerConnection.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineSchedulerConnectionFactory.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineSchedulerConnectionFactory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineSetup.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineSetup.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineXmlParser.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineXmlParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/gridengine/ParallelEnvironmentInfo.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/gridengine/ParallelEnvironmentInfo.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/gridengine/QueueInfo.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/gridengine/QueueInfo.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalAdaptor.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalAdaptor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalCredential.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalCredential.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.local;
 
 import java.util.HashMap;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalCredentials.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalCredentials.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.local;
 
 import java.util.Map;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalDirectoryAttributeStream.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalDirectoryAttributeStream.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalDirectoryStream.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalDirectoryStream.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalFileAttributes.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalFileAttributes.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalFiles.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalFiles.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalInteractiveProcess.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalInteractiveProcess.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalJobs.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalJobs.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalUtils.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalUtils.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/ForwardingCredentials.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/ForwardingCredentials.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/RemoteCommandRunner.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/RemoteCommandRunner.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/SchedulerConnection.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/SchedulerConnection.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/SchedulerConnectionFactory.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/SchedulerConnectionFactory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/ScriptingAdaptor.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/ScriptingAdaptor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.scripting;
 
 import nl.esciencecenter.xenon.XenonException;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/ScriptingJobs.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/ScriptingJobs.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/ScriptingParser.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/ScriptingParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmAdaptor.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmAdaptor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmJobScriptGenerator.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmJobScriptGenerator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.esciencecenter.xenon.adaptors.slurm;
 
 import java.util.ArrayList;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmSchedulerConnection.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmSchedulerConnection.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmSchedulerConnectionFactory.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmSchedulerConnectionFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.esciencecenter.xenon.adaptors.slurm;
 
 import nl.esciencecenter.xenon.XenonException;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmSetup.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmSetup.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/ConnectionLostException.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/ConnectionLostException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/EndOfFileException.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/EndOfFileException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/NotConnectedException.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/NotConnectedException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/OpenSSHConfig.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/OpenSSHConfig.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/PermissionDeniedException.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/PermissionDeniedException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/Robot.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/Robot.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import com.jcraft.jsch.UserInfo;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshAdaptor.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshAdaptor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshCredentials.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshCredentials.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshDirectoryAttributeStream.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshDirectoryAttributeStream.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshDirectoryStream.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshDirectoryStream.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshFileAttributes.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshFileAttributes.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshFiles.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshFiles.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshInputStream.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshInputStream.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshInteractiveProcess.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshInteractiveProcess.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import java.io.IOException;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshInteractiveProcessFactory.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshInteractiveProcessFactory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import nl.esciencecenter.xenon.XenonException;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshJobs.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshJobs.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshLocation.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshLocation.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import nl.esciencecenter.xenon.InvalidLocationException;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshMultiplexedSession.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshMultiplexedSession.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import java.util.ArrayList;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshOutputStream.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshOutputStream.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshSession.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshSession.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import nl.esciencecenter.xenon.XenonException;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshUtil.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import nl.esciencecenter.xenon.XenonException;

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/UnsupportedIOOperationException.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/UnsupportedIOOperationException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/torque/TorqueAdaptor.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/torque/TorqueAdaptor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/torque/TorqueJobScriptGenerator.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/torque/TorqueJobScriptGenerator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/torque/TorqueSchedulerConnection.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/torque/TorqueSchedulerConnection.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/torque/TorqueSchedulerConnectionFactory.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/torque/TorqueSchedulerConnectionFactory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/torque/TorqueXmlParser.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/torque/TorqueXmlParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/credentials/CertificateNotFoundException.java
+++ b/src/main/java/nl/esciencecenter/xenon/credentials/CertificateNotFoundException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.credentials;
 
 import nl.esciencecenter.xenon.XenonException;

--- a/src/main/java/nl/esciencecenter/xenon/credentials/Credential.java
+++ b/src/main/java/nl/esciencecenter/xenon/credentials/Credential.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/credentials/Credentials.java
+++ b/src/main/java/nl/esciencecenter/xenon/credentials/Credentials.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/credentials/package-info.java
+++ b/src/main/java/nl/esciencecenter/xenon/credentials/package-info.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * This package contains classes and interfaces for managing credentials.
  */

--- a/src/main/java/nl/esciencecenter/xenon/engine/Adaptor.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/Adaptor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/AdaptorStatusImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/AdaptorStatusImplementation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/PropertyTypeException.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/PropertyTypeException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/XenonEngine.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/XenonEngine.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/XenonProperties.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/XenonProperties.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/XenonPropertyDescriptionImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/XenonPropertyDescriptionImplementation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine;
 
 import java.util.HashSet;

--- a/src/main/java/nl/esciencecenter/xenon/engine/credentials/CertificateCredentialImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/credentials/CertificateCredentialImplementation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/credentials/CredentialImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/credentials/CredentialImplementation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/credentials/CredentialsEngineImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/credentials/CredentialsEngineImplementation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/credentials/PasswordCredentialImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/credentials/PasswordCredentialImplementation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/credentials/ProxyCredentialImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/credentials/ProxyCredentialImplementation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/files/CopyImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/files/CopyImplementation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.files;
 
 import nl.esciencecenter.xenon.files.Copy;

--- a/src/main/java/nl/esciencecenter/xenon/engine/files/CopyStatusImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/files/CopyStatusImplementation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.files;
 
 import nl.esciencecenter.xenon.files.Copy;

--- a/src/main/java/nl/esciencecenter/xenon/engine/files/FileSystemImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/files/FileSystemImplementation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/files/FilesEngine.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/files/FilesEngine.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/files/PathAttributesPairImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/files/PathAttributesPairImplementation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/files/PathImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/files/PathImplementation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/jobs/JobImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/jobs/JobImplementation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/jobs/JobStatusImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/jobs/JobStatusImplementation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/jobs/JobsEngine.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/jobs/JobsEngine.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/jobs/QueueStatusImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/jobs/QueueStatusImplementation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/jobs/SchedulerImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/jobs/SchedulerImplementation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/jobs/StreamsImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/jobs/StreamsImplementation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.jobs;
 
 import java.io.InputStream;

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/BadParameterException.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/BadParameterException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/BatchProcess.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/BatchProcess.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/CommandLineUtils.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/CommandLineUtils.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/CommandNotFoundException.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/CommandNotFoundException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/CommandRunner.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/CommandRunner.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/CopyEngine.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/CopyEngine.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.util;
 
 import java.io.Closeable;

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/CopyInfo.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/CopyInfo.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.util;
 
 import nl.esciencecenter.xenon.engine.files.CopyImplementation;

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/ImmutableArray.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/ImmutableArray.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.util;
 
 import java.util.Arrays;

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/InputWriter.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/InputWriter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/InteractiveProcess.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/InteractiveProcess.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.util;
 
 import nl.esciencecenter.xenon.jobs.Streams;

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/InteractiveProcessFactory.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/InteractiveProcessFactory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.util;
 
 import nl.esciencecenter.xenon.XenonException;

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/JobExecutor.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/JobExecutor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.util;
 
 import java.io.IOException;

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/JobQueues.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/JobQueues.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.util;
 
 import java.util.Iterator;

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/OpenOptions.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/OpenOptions.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.util;
 
 import nl.esciencecenter.xenon.files.InvalidOpenOptionsException;

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/OutputReader.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/OutputReader.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/PosixFileUtils.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/PosixFileUtils.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.util;
 
 import java.util.HashSet;

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/Process.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/Process.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.util;
 
 /**

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/StreamForwarder.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/StreamForwarder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/AttributeNotSupportedException.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/AttributeNotSupportedException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/Copy.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/Copy.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.files;
 
 /**

--- a/src/main/java/nl/esciencecenter/xenon/files/CopyOption.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/CopyOption.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/CopyStatus.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/CopyStatus.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.files;
 
 /**

--- a/src/main/java/nl/esciencecenter/xenon/files/DirectoryNotEmptyException.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/DirectoryNotEmptyException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/DirectoryStream.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/DirectoryStream.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/FileAttributes.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/FileAttributes.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/FileSystem.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/FileSystem.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/FileSystemClosedException.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/FileSystemClosedException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/Files.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/Files.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/IllegalSourcePathException.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/IllegalSourcePathException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/IllegalTargetPathException.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/IllegalTargetPathException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/InvalidCopyOptionsException.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/InvalidCopyOptionsException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/InvalidOpenOptionsException.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/InvalidOpenOptionsException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/InvalidResumeTargetException.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/InvalidResumeTargetException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/NoSuchCopyException.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/NoSuchCopyException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/NoSuchPathException.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/NoSuchPathException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/OpenOption.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/OpenOption.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/Path.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/Path.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/PathAlreadyExistsException.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/PathAlreadyExistsException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/PathAttributesPair.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/PathAttributesPair.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/PosixFilePermission.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/PosixFilePermission.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/RelativePath.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/RelativePath.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/files/package-info.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/package-info.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * This package contains classes and interfaces for manipulating files.
  */

--- a/src/main/java/nl/esciencecenter/xenon/jobs/IncompleteJobDescriptionException.java
+++ b/src/main/java/nl/esciencecenter/xenon/jobs/IncompleteJobDescriptionException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/jobs/InvalidJobDescriptionException.java
+++ b/src/main/java/nl/esciencecenter/xenon/jobs/InvalidJobDescriptionException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/jobs/Job.java
+++ b/src/main/java/nl/esciencecenter/xenon/jobs/Job.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/jobs/JobCanceledException.java
+++ b/src/main/java/nl/esciencecenter/xenon/jobs/JobCanceledException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/jobs/JobDescription.java
+++ b/src/main/java/nl/esciencecenter/xenon/jobs/JobDescription.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/jobs/JobStatus.java
+++ b/src/main/java/nl/esciencecenter/xenon/jobs/JobStatus.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/jobs/Jobs.java
+++ b/src/main/java/nl/esciencecenter/xenon/jobs/Jobs.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/jobs/NoSuchJobException.java
+++ b/src/main/java/nl/esciencecenter/xenon/jobs/NoSuchJobException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/jobs/NoSuchQueueException.java
+++ b/src/main/java/nl/esciencecenter/xenon/jobs/NoSuchQueueException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/jobs/NoSuchSchedulerException.java
+++ b/src/main/java/nl/esciencecenter/xenon/jobs/NoSuchSchedulerException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/jobs/QueueStatus.java
+++ b/src/main/java/nl/esciencecenter/xenon/jobs/QueueStatus.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/jobs/Scheduler.java
+++ b/src/main/java/nl/esciencecenter/xenon/jobs/Scheduler.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/jobs/Streams.java
+++ b/src/main/java/nl/esciencecenter/xenon/jobs/Streams.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.jobs;
 
 import java.io.InputStream;

--- a/src/main/java/nl/esciencecenter/xenon/jobs/UnsupportedJobDescriptionException.java
+++ b/src/main/java/nl/esciencecenter/xenon/jobs/UnsupportedJobDescriptionException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/jobs/package-info.java
+++ b/src/main/java/nl/esciencecenter/xenon/jobs/package-info.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * This package contains the classes and interfaces used to run jobs.
  */

--- a/src/main/java/nl/esciencecenter/xenon/package-info.java
+++ b/src/main/java/nl/esciencecenter/xenon/package-info.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * This package is the main entry point into the Xenon API.
  */

--- a/src/main/java/nl/esciencecenter/xenon/util/AdaptorDocGenerator.java
+++ b/src/main/java/nl/esciencecenter/xenon/util/AdaptorDocGenerator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.util;
 
 import java.io.BufferedWriter;

--- a/src/main/java/nl/esciencecenter/xenon/util/FileVisitResult.java
+++ b/src/main/java/nl/esciencecenter/xenon/util/FileVisitResult.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/util/FileVisitor.java
+++ b/src/main/java/nl/esciencecenter/xenon/util/FileVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/util/JavaJobDescription.java
+++ b/src/main/java/nl/esciencecenter/xenon/util/JavaJobDescription.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/util/Sandbox.java
+++ b/src/main/java/nl/esciencecenter/xenon/util/Sandbox.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/util/Utils.java
+++ b/src/main/java/nl/esciencecenter/xenon/util/Utils.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/nl/esciencecenter/xenon/util/package-info.java
+++ b/src/main/java/nl/esciencecenter/xenon/util/package-info.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * This package is contains several utility classes.
  */

--- a/src/test/java/nl/esciencecenter/xenon/JobException.java
+++ b/src/test/java/nl/esciencecenter/xenon/JobException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/Util.java
+++ b/src/test/java/nl/esciencecenter/xenon/Util.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon;
 
 import java.lang.reflect.Constructor;

--- a/src/test/java/nl/esciencecenter/xenon/XenonFactoryTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/XenonFactoryTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/XenonTestWatcher.java
+++ b/src/test/java/nl/esciencecenter/xenon/XenonTestWatcher.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/CredentialTestConfig.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/CredentialTestConfig.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors;
 
 import java.io.IOException;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/FileTestConfig.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/FileTestConfig.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors;
 
 import java.io.FileNotFoundException;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/GenericCredentialsAdaptorTestParent.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/GenericCredentialsAdaptorTestParent.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors;
 
 import static org.junit.Assert.fail;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/GenericTestConfig.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/GenericTestConfig.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors;
 
 import java.io.File;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/JobTestConfig.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/JobTestConfig.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors;
 
 import java.io.FileNotFoundException;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/ftp/FTPFileTestConfig.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/ftp/FTPFileTestConfig.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ftp;
 
 import java.util.HashMap;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/ftp/FTPLocationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/ftp/FTPLocationTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.esciencecenter.xenon.adaptors.ftp;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/ftp/FtpFileAttributesTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/ftp/FtpFileAttributesTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.esciencecenter.xenon.adaptors.ftp;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/ftp/FtpInputStreamTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/ftp/FtpInputStreamTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.esciencecenter.xenon.adaptors.ftp;
 
 import static org.mockito.Mockito.mock;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/ftp/FtpOutputStreamTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/ftp/FtpOutputStreamTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.esciencecenter.xenon.adaptors.ftp;
 
 import static org.mockito.Mockito.mock;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineJobScriptGeneratorTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineJobScriptGeneratorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineJobTestConfig.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineJobTestConfig.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.gridengine;
 
 import java.util.HashMap;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineSchedulerConnectionTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineSchedulerConnectionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineSetupTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineSetupTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineXmlParserTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineXmlParserTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/gridengine/ParallelEnvironmentInfoTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/gridengine/ParallelEnvironmentInfoTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/gridengine/QueueInfoTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/gridengine/QueueInfoTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/local/LocalCredentialTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/local/LocalCredentialTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.local;
 
 import org.junit.BeforeClass;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/local/LocalCredentialTestConfig.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/local/LocalCredentialTestConfig.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.local;
 
 import nl.esciencecenter.xenon.adaptors.CredentialTestConfig;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/local/LocalDirectoryAttributeStreamTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/local/LocalDirectoryAttributeStreamTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.local;
 
 import java.util.HashMap;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/local/LocalDirectoryStreamTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/local/LocalDirectoryStreamTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.local;
 
 import static org.mockito.Mockito.mock;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/local/LocalFileAttributesTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/local/LocalFileAttributesTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.local;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/local/LocalFileTestConfig.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/local/LocalFileTestConfig.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.local;
 
 import java.util.Map;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/local/LocalJobTestConfig.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/local/LocalJobTestConfig.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.local;
 
 import java.util.Map;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/local/LocalUtilsTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/local/LocalUtilsTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.local;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/scripting/FakeScriptingJob.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/scripting/FakeScriptingJob.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/scripting/FakeScriptingScheduler.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/scripting/FakeScriptingScheduler.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/scripting/SchedulerConnectionTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/scripting/SchedulerConnectionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/scripting/ScriptingParserTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/scripting/ScriptingParserTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmJobScriptGeneratorTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmJobScriptGeneratorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmJobTestConfig.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmJobTestConfig.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.slurm;
 
 import java.util.HashMap;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmSchedulerConnectionTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmSchedulerConnectionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmSetupTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmSetupTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/OpenSSHConfigTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/OpenSSHConfigTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/RobotTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/RobotTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/SSHCredentialTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/SSHCredentialTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import static org.junit.Assert.*;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/SSHCredentialTestConfig.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/SSHCredentialTestConfig.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import java.io.File;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/SSHFileAttributeTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/SSHFileAttributeTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/SSHFileTestConfig.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/SSHFileTestConfig.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import java.util.HashMap;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/SSHJobTestConfig.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/SSHJobTestConfig.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import java.util.HashMap;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/SSHLocationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/SSHLocationTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/SSHUtilTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/SSHUtilTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import static org.junit.Assert.*;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/SshInputStreamTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/SshInputStreamTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/SshOutputStreamTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/ssh/SshOutputStreamTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.adaptors.ssh;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/torque/TorqueJobScriptGeneratorTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/torque/TorqueJobScriptGeneratorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/torque/TorqueJobTestConfig.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/torque/TorqueJobTestConfig.java
@@ -1,4 +1,18 @@
-
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /*
  * Copyright 2013 Netherlands eScience Center
  *

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/torque/TorqueSchedulerConnectionTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/torque/TorqueSchedulerConnectionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/torque/TorqueXmlParserTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/torque/TorqueXmlParserTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/engine/AdaptorStatusImplementationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/AdaptorStatusImplementationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/engine/AdaptorTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/AdaptorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/engine/XenonEngineTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/XenonEngineTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/engine/XenonPropertiesTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/XenonPropertiesTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/engine/credentials/CertificateCredentialImplementationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/credentials/CertificateCredentialImplementationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.credentials;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/engine/credentials/CredentialsEngineImplementationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/credentials/CredentialsEngineImplementationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.credentials;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/engine/credentials/PasswordCredentialImplementationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/credentials/PasswordCredentialImplementationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.credentials;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/engine/files/CopyImplementationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/files/CopyImplementationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.files;
 
 import static org.junit.Assert.assertNull;

--- a/src/test/java/nl/esciencecenter/xenon/engine/files/CopyStatusImplementationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/files/CopyStatusImplementationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.files;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/nl/esciencecenter/xenon/engine/files/FileSystemImplementationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/files/FileSystemImplementationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.files;
 
 import static org.junit.Assert.*;

--- a/src/test/java/nl/esciencecenter/xenon/engine/files/FilesEngineTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/files/FilesEngineTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/engine/files/PathAttributesPairImplementationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/files/PathAttributesPairImplementationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.files;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/nl/esciencecenter/xenon/engine/files/PathImplementationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/files/PathImplementationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.files;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/engine/jobs/JobImplementationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/jobs/JobImplementationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.jobs;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/engine/jobs/JobStatusImplementationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/jobs/JobStatusImplementationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.jobs;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/engine/jobs/JobsEngineTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/jobs/JobsEngineTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/engine/jobs/QueueStatusImplementationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/jobs/QueueStatusImplementationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.jobs;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/engine/jobs/SchedulerImplementationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/jobs/SchedulerImplementationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.jobs;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/engine/jobs/StreamsImplementationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/jobs/StreamsImplementationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.jobs;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/engine/util/ImmutableArrayTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/util/ImmutableArrayTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.util;
 
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/nl/esciencecenter/xenon/engine/util/JobQueueTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/util/JobQueueTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.util;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/nl/esciencecenter/xenon/engine/util/PosixFileUtilsTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/util/PosixFileUtilsTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.engine.util;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/exceptions/ExceptionsTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/exceptions/ExceptionsTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.exceptions;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/files/CopyOptionTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/files/CopyOptionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/files/OpenOptionTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/files/OpenOptionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.files;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/nl/esciencecenter/xenon/files/RelativePathIteratorTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/files/RelativePathIteratorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.files;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/files/RelativePathTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/files/RelativePathTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/jobs/JobDescriptionTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/jobs/JobDescriptionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.jobs;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/util/AdaptorDocGeneratorTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/util/AdaptorDocGeneratorTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.esciencecenter.xenon.util;
 
 import static org.hamcrest.CoreMatchers.containsString;

--- a/src/test/java/nl/esciencecenter/xenon/util/FileUtilsTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/util/FileUtilsTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/util/JavaJobDescriptionTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/util/JavaJobDescriptionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/util/RealFileUtilsTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/util/RealFileUtilsTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/nl/esciencecenter/xenon/util/RealSandboxTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/util/RealSandboxTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.util;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/esciencecenter/xenon/util/SandboxTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/util/SandboxTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2013 Netherlands eScience Center
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.esciencecenter.xenon.util;
 
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
This task is a dependency of the `check` task so it will run during `./gradlew check`.

The license plugin can also add license headers if missing with the `licenseFormat` task.
The `licenseFormat` task has been run to fix files with missing headers.
