### PR TITLE
Added timeout to ssh-fillpass-xenon

### DIFF
--- a/src/integrationTest/docker/ssh-fillpass-xenon
+++ b/src/integrationTest/docker/ssh-fillpass-xenon
@@ -1,5 +1,6 @@
-#!/usr/bin/expect -f
+#!/usr/bin/expect
+set timeout 15
 spawn ssh-add /home/xenon/.ssh/id_dsa
 expect "Enter passphrase for /home/xenon/.ssh/id_dsa:"
-send "javagat2\n";
-interact
+send "javagat2\r"
+expect eof


### PR DESCRIPTION
Previously running `docker run --rm nlesc/xenon-test ssh-add -l` sometimes gave `The agent has no identities.` message.
After adding timeout have not seen this message.

Refs #248