### PR TITLE
Drop document build dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,26 +17,18 @@ matrix:
       env:
         - GRADLE_BUILD_TASKS="assemble"
         - GRADLE_SCRIPT_TASKS="check"
+        - INTEGRATION_TEST=0
         - JDK=openjdk7
       sudo: false
     - jdk: oraclejdk8
       env:
         - GRADLE_BUILD_TASKS="assemble"
         - GRADLE_SCRIPT_TASKS="check"
+        - INTEGRATION_TEST=0
         - JDK=oraclejdk8
       sudo: false
   # Stop when one of the Java versions do not work
   fast_finish: true
-
-# Install documentation dependencies
-addons:
-  apt_packages:
-    - pandoc
-    - texlive
-    - texlive-latex-extra
-    - texlive-font-utils
-    - inkscape
-    - lmodern
 
 # Install Docker compose
 before_install:

--- a/doc/README.md
+++ b/doc/README.md
@@ -17,7 +17,7 @@ Use `./gradlew tasks` to list all available tasks.
 Prerequisites:
 
 * JDK
-* Gradle, http://gradle.org/
+* Gradle, http://gradle.org/, tested with version 2.9
 
 The dist can be built offline with
 ```
@@ -66,9 +66,9 @@ Prerequisites:
   * 2 Cores (required by some schedulers)
   * Xenon repo not residing on a Virtualbox share
   * Minimal 2Gb RAM
-* Docker, https://www.docker.com/
+* Docker, https://www.docker.com/, tested with version 1.9.1
   * Without sudo
-* Docker compose, https://docs.docker.com/compose/
+* Docker compose, https://docs.docker.com/compose/, tested with version 1.5.0
 
 Integrations tests will be run inside a docker image against several docker containers containing servers for all the Xenon adaptors.
 


### PR DESCRIPTION
The documentation generation has moved to https://github.com/NLeSC/Xenon-examples repository.