### PR TITLE
Windows quircks

### DIFF
--- a/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalFileAttributes.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalFileAttributes.java
@@ -93,13 +93,15 @@ public class LocalFileAttributes implements FileAttributes {
             executable = Files.isExecutable(javaPath);
             readable = Files.isReadable(javaPath);
             writable = Files.isWritable(javaPath);
-            hidden = Files.isHidden(javaPath);
-
+            
             isWindows = Utils.isWindows(); 
 
             BasicFileAttributes basicAttributes;
             
             if (isWindows) {                
+                // TODO: Seems to fail in Windows ?
+                hidden = false;
+                
                 // These should always work.
                 basicAttributes = Files.readAttributes(javaPath, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
                 
@@ -110,7 +112,9 @@ public class LocalFileAttributes implements FileAttributes {
                 group = null;
                 permissions = null;
                 owner = null;
-            } else { 
+            } else {
+                hidden = Files.isHidden(javaPath);
+                
                 // Note: when in a posix environment, basicAttributes point to posixAttributes.
                 PosixFileAttributes posixAttributes = Files.readAttributes(javaPath, PosixFileAttributes.class, 
                         LinkOption.NOFOLLOW_LINKS);

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalUtils.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalUtils.java
@@ -47,6 +47,10 @@ import nl.esciencecenter.xenon.util.Utils;
  */
 final class LocalUtils {
 
+    // Windows occasionally refuses to delete a directory because is it locked by some external service (i.e., virus scanner). 
+    // The only solution to this is to retry the delete a couple of times. This constant sets the number of attempts to be done.
+    private static final int WINDOWS_EXTRA_DELETE_ATTEMPTS = 1000;
+
     private LocalUtils() {
         // DO NOT USE
     }
@@ -196,7 +200,7 @@ final class LocalUtils {
             Files.delete(LocalUtils.javaPath(path));
         } catch (java.nio.file.NoSuchFileException e1) {
             throw new NoSuchPathException(LocalAdaptor.ADAPTOR_NAME, "File " + path + " does not exist!", e1);
-        } catch (java.nio.file.DirectoryNotEmptyException e2) {
+        } catch (java.nio.file.DirectoryNotEmptyException e2) {            
             throw new DirectoryNotEmptyException(LocalAdaptor.ADAPTOR_NAME, "Directory " + path + " not empty!", e2);
         } catch (IOException e) {
             throw new XenonException(LocalAdaptor.ADAPTOR_NAME, "Failed to delete file " + path, e);

--- a/src/main/java/nl/esciencecenter/xenon/util/Utils.java
+++ b/src/main/java/nl/esciencecenter/xenon/util/Utils.java
@@ -506,7 +506,7 @@ public final class Utils {
 
     /**
      * Provided with an absolute <code>path</code> and a <code>root</code>, this method returns a <code>RelativePath</code> that
-     * represents the part of <code>path</code> that is realtive to the <code>root</code>.
+     * represents the part of <code>path</code> that is relative to the <code>root</code>.
      *
      * For example, if "C:\dir\file" is provided as <code>path</code> and "C:" as <code>root</code>, a <code>RelativePath</code>
      * will be returned that represents "dir\file".

--- a/src/main/java/nl/esciencecenter/xenon/util/Utils.java
+++ b/src/main/java/nl/esciencecenter/xenon/util/Utils.java
@@ -37,6 +37,7 @@ import nl.esciencecenter.xenon.InvalidLocationException;
 import nl.esciencecenter.xenon.XenonException;
 import nl.esciencecenter.xenon.credentials.Credential;
 import nl.esciencecenter.xenon.files.CopyOption;
+import nl.esciencecenter.xenon.files.DirectoryStream;
 import nl.esciencecenter.xenon.files.FileAttributes;
 import nl.esciencecenter.xenon.files.FileSystem;
 import nl.esciencecenter.xenon.files.Files;
@@ -964,8 +965,13 @@ public final class Utils {
             if (attributes.isDirectory() && maxDepth > 0) {
                 visitResult = visitor.preVisitDirectory(path, attributes, files);
                 if (visitResult == FileVisitResult.CONTINUE) {
+                    
+                    DirectoryStream<PathAttributesPair> stream = null;
+                    
                     try {
-                        for (PathAttributesPair attributesEntry : files.newAttributesDirectoryStream(path)) {
+                        stream = files.newAttributesDirectoryStream(path); 
+                       
+                        for (PathAttributesPair attributesEntry : stream) {
                             // recursion step
                             FileVisitResult result = walk(files, attributesEntry.path(), attributesEntry.attributes(),
                                     followLinks, maxDepth - 1, visitor);
@@ -979,6 +985,14 @@ public final class Utils {
                         }
                     } catch (XenonException e) {
                         exception = e;
+                    } finally { 
+                        if (stream != null) { 
+                            try {
+                                stream.close();
+                            } catch (IOException e) {
+                                // TODO: ignored for now, should log ?  
+                            }
+                        }
                     }
                     return visitor.postVisitDirectory(path, exception, files);
                 } else if (visitResult == FileVisitResult.SKIP_SIBLINGS) {
@@ -1053,11 +1067,27 @@ public final class Utils {
             } else {
                 files.createDirectories(target);
             }
-            for (Path f : files.newDirectoryStream(source)) {
-                Path ftarget = files.newPath(target.getFileSystem(),
-                        target.getRelativePath().resolve(f.getRelativePath().getFileName()));
-                recursiveCopy(files, f, ftarget, options);
+            
+            DirectoryStream<Path> stream  = null;
+            
+            try { 
+                stream = files.newDirectoryStream(source);
+
+                for (Path f : stream) {
+                    Path ftarget = files.newPath(target.getFileSystem(),
+                            target.getRelativePath().resolve(f.getRelativePath().getFileName()));
+                    recursiveCopy(files, f, ftarget, options);
+                }
+            } finally { 
+                if (stream != null) { 
+                    try {
+                        stream.close();
+                    } catch (IOException e) {
+                        // TODO: ignored for now -- should LOG ?
+                    }
+                } 
             }
+                
         } else {
             if (exist) {
                 if (ignore) {
@@ -1089,8 +1119,23 @@ public final class Utils {
         FileAttributes att = files.getAttributes(path);
 
         if (att.isDirectory()) {
-            for (Path f : files.newDirectoryStream(path)) {
-                Utils.recursiveDelete(files, f);
+
+            DirectoryStream<Path> stream = null;
+            
+            try {             
+                stream = files.newDirectoryStream(path);
+                
+                for (Path f : stream) {
+                    Utils.recursiveDelete(files, f);
+                }
+            } finally { 
+                if (stream != null) { 
+                    try {
+                        stream.close();
+                    } catch (IOException e) {
+                        // TODO: ignored for now, should LOG
+                    }
+                }
             }
         }
         files.delete(path);

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/local/LocalDirectoryAttributeStreamTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/local/LocalDirectoryAttributeStreamTest.java
@@ -140,7 +140,31 @@ public class LocalDirectoryAttributeStreamTest {
     @org.junit.Test(expected = XenonException.class)
     public void test_nonexistant_dir() throws Exception {
         Path path = new PathImplementation(fs, new RelativePath("aap"));
-        new LocalDirectoryAttributeStream(localFiles, new LocalDirectoryStream(path, new AllTrue()));
+        
+        LocalDirectoryStream s1 = null;
+        LocalDirectoryAttributeStream s2 = null;
+        
+        // NOTE: we need to properly close the streams, or the test will alway fail on windows.        
+        try { 
+            s1 = new LocalDirectoryStream(path, new AllTrue());
+            s2 = new LocalDirectoryAttributeStream(localFiles, s1);
+        } finally { 
+            if (s1 != null) {
+                try { 
+                    s1.close();
+                } catch (Exception e) { 
+                    // ignored
+                }
+            }
+            
+            if (s2 != null) {
+                try { 
+                    s2.close();
+                } catch (Exception e) { 
+                    // ignored
+                }
+            }
+        }
     }
 
     @org.junit.Test
@@ -194,7 +218,11 @@ public class LocalDirectoryAttributeStreamTest {
         LocalDirectoryAttributeStream stream = new LocalDirectoryAttributeStream(localFiles, new LocalDirectoryStream(testDir,
                 new AllFalse()));
 
-        stream.next();
+        try { 
+            stream.next();
+        } finally { 
+            stream.close();
+        }
     }
 
     @org.junit.Test(expected = NoSuchElementException.class)
@@ -203,9 +231,13 @@ public class LocalDirectoryAttributeStreamTest {
         LocalDirectoryAttributeStream stream = new LocalDirectoryAttributeStream(localFiles, new LocalDirectoryStream(testDir,
                 new AllTrue()));
 
-        // expecting at most 10000 items, otherwise, the stream might go on forever
-        for (int i = 0; i < 10000; i++) {
-            stream.next();
+        try { 
+            // expecting at most 10000 items, otherwise, the stream might go on forever
+            for (int i = 0; i < 10000; i++) {
+                stream.next();
+            }
+        } finally { 
+            stream.close();
         }
     }
 
@@ -225,12 +257,14 @@ public class LocalDirectoryAttributeStreamTest {
         LocalDirectoryAttributeStream stream = new LocalDirectoryAttributeStream(localFiles, new LocalDirectoryStream(dir0,
                 new AllTrue()));
 
-        while (stream.hasNext()) {
-            localFiles.delete(file4);
-            stream.next();
+        try { 
+            while (stream.hasNext()) {
+                localFiles.delete(file4);
+                stream.next();
+            }
+        } finally { 
+            stream.close();
         }
-
-        stream.close();
     }
 
     @org.junit.Test(expected = UnsupportedOperationException.class)
@@ -239,7 +273,11 @@ public class LocalDirectoryAttributeStreamTest {
         LocalDirectoryAttributeStream stream = new LocalDirectoryAttributeStream(localFiles, new LocalDirectoryStream(testDir,
                 new AllTrue()));
 
-        stream.remove();
+        try { 
+            stream.remove();
+        } finally { 
+            stream.close();
+        }
     }
 
     @org.junit.Test
@@ -250,4 +288,5 @@ public class LocalDirectoryAttributeStreamTest {
         stream.close();
         stream.close();
     }
+    
 }

--- a/src/test/java/nl/esciencecenter/xenon/util/RealFileUtilsTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/util/RealFileUtilsTest.java
@@ -67,29 +67,9 @@ public class RealFileUtilsTest {
         files.createDirectory(testDir);
     }
     
-    public static void delete(Path path) throws Exception {
-
-        if (Utils.isWindows()) { 
-            
-            for (int i=0;i<3;i++) {
-                try { 
-                    files.delete(path);
-                    return;
-                } catch (DirectoryNotEmptyException e) { 
-                    // Windows may occasionally refuse to delete a directory as it seems to be confused if it is in use or not,
-                    // so we retry a few times.
-                }
-            }
-            
-        } else { 
-            files.delete(path);
-        }
-    }
-    
-
     @AfterClass
     public static void cleanup() throws Exception {
-        delete(testDir);
+        files.delete(testDir);
         XenonFactory.endXenon(xenon);
     }
 
@@ -108,7 +88,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.length > 0);
         assertTrue(message.equals(new String(tmp)));
 
-        delete(testFile);
+        files.delete(testFile);
     }
 
     @Test
@@ -127,7 +107,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.length > 0);
         assertTrue(message.equals(new String(tmp)));
 
-        delete(testFile);
+        files.delete(testFile);
     }
 
     @Test
@@ -146,7 +126,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.length > 0);
         assertTrue(new String(tmp).equals(message + message));
 
-        delete(testFile);
+        files.delete(testFile);
     }
 
     @Test
@@ -168,7 +148,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.length > 0);
         assertTrue(new String(tmp).equals(message));
 
-        delete(testFile);
+        files.delete(testFile);
     }
 
     @Test
@@ -191,7 +171,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.length > 0);
         assertTrue(new String(tmp).equals(message));
 
-        delete(testFile);
+        files.delete(testFile);
     }
 
     @Test
@@ -214,7 +194,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.length > 0);
         assertTrue(new String(tmp).equals(message + message));
 
-        delete(testFile);
+        files.delete(testFile);
     }
 
     @Test
@@ -234,7 +214,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.length > 0);
         assertTrue(new String(tmp).equals(message));
 
-        delete(testFile);
+        files.delete(testFile);
     }
 
     @Test
@@ -258,7 +238,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.length > 0);
         assertTrue(new String(tmp).equals(message));
 
-        delete(testFile);
+        files.delete(testFile);
     }
 
     @Test
@@ -282,7 +262,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.length > 0);
         assertTrue(new String(tmp).equals(message + message));
 
-        delete(testFile);
+        files.delete(testFile);
     }
 
     @Test
@@ -302,7 +282,7 @@ public class RealFileUtilsTest {
         assertNotNull(tmp);
         assertTrue(tmp.equals(message));
 
-        delete(testFile);
+        files.delete(testFile);
     }
 
     @Test
@@ -327,7 +307,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp1.equals("Hello World!"));
         assertTrue(tmp2.equals("Hello World!"));
 
-        delete(testFile);
+        files.delete(testFile);
     }
 
     @Test
@@ -351,7 +331,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.get(2).equals("line3"));
         assertTrue(tmp.get(3).equals("line4"));
 
-        delete(testFile);
+        files.delete(testFile);
     }
 
     @Test
@@ -378,7 +358,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp2.get(2).equals("line3"));
         assertTrue(tmp2.get(3).equals("line4"));
 
-        delete(testFile);
+        files.delete(testFile);
     }
 
     @SuppressWarnings("CanBeFinal")
@@ -453,11 +433,11 @@ public class RealFileUtilsTest {
         Utils.walkFileTree(files, dirs[0], fv);
 
         for (int i = 0; i < 10; i++) {
-            delete(tmp[i]);
+            files.delete(tmp[i]);
         }
 
-        delete(dirs[1]);
-        delete(dirs[0]);
+        files.delete(dirs[1]);
+        files.delete(dirs[0]);
     }
 
     class MyFileVisitor2 implements FileVisitor {
@@ -507,11 +487,11 @@ public class RealFileUtilsTest {
         Utils.walkFileTree(files, dirs[0], fv);
 
         for (int i = 0; i < 10; i++) {
-            delete(tmp[i]);
+            files.delete(tmp[i]);
         }
 
-        delete(dirs[1]);
-        delete(dirs[0]);
+        files.delete(dirs[1]);
+        files.delete(dirs[0]);
     }
 
     class MyFileVisitor3 implements FileVisitor {
@@ -561,11 +541,11 @@ public class RealFileUtilsTest {
         Utils.walkFileTree(files, dirs[0], fv);
 
         for (int i = 0; i < 10; i++) {
-            delete(tmp[i]);
+            files.delete(tmp[i]);
         }
 
-        delete(dirs[1]);
-        delete(dirs[0]);
+        files.delete(dirs[1]);
+        files.delete(dirs[0]);
     }
 
     class MyFileVisitor4 implements FileVisitor {
@@ -632,12 +612,12 @@ public class RealFileUtilsTest {
         Utils.walkFileTree(files, dirs[0], fv);
 
         for (int i = 0; i < 10; i++) {
-            delete(tmp[i]);
+            files.delete(tmp[i]);
         }
 
-        delete(dirs[2]);
-        delete(dirs[1]);
-        delete(dirs[0]);
+        files.delete(dirs[2]);
+        files.delete(dirs[1]);
+        files.delete(dirs[0]);
     }
 
     class MyFileVisitor5 implements FileVisitor {
@@ -687,11 +667,11 @@ public class RealFileUtilsTest {
         Utils.walkFileTree(files, dirs[0], fv);
 
         for (int i = 0; i < 10; i++) {
-            delete(tmp[i]);
+            files.delete(tmp[i]);
         }
 
-        delete(dirs[1]);
-        delete(dirs[0]);
+        files.delete(dirs[1]);
+        files.delete(dirs[0]);
     }
 
     class MyFileVisitor6 implements FileVisitor {

--- a/src/test/java/nl/esciencecenter/xenon/util/RealFileUtilsTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/util/RealFileUtilsTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import nl.esciencecenter.xenon.Xenon;
 import nl.esciencecenter.xenon.XenonException;
 import nl.esciencecenter.xenon.XenonFactory;
+import nl.esciencecenter.xenon.files.DirectoryNotEmptyException;
 import nl.esciencecenter.xenon.files.FileAttributes;
 import nl.esciencecenter.xenon.files.FileSystem;
 import nl.esciencecenter.xenon.files.Files;
@@ -65,10 +66,30 @@ public class RealFileUtilsTest {
         testDir = files.newPath(fileSystem, cwd.getRelativePath().resolve(ROOT));
         files.createDirectory(testDir);
     }
+    
+    public static void delete(Path path) throws Exception {
+
+        if (Utils.isWindows()) { 
+            
+            for (int i=0;i<3;i++) {
+                try { 
+                    files.delete(path);
+                    return;
+                } catch (DirectoryNotEmptyException e) { 
+                    // Windows may occasionally refuse to delete a directory as it seems to be confused if it is in use or not,
+                    // so we retry a few times.
+                }
+            }
+            
+        } else { 
+            files.delete(path);
+        }
+    }
+    
 
     @AfterClass
     public static void cleanup() throws Exception {
-        files.delete(testDir);
+        delete(testDir);
         XenonFactory.endXenon(xenon);
     }
 
@@ -87,7 +108,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.length > 0);
         assertTrue(message.equals(new String(tmp)));
 
-        files.delete(testFile);
+        delete(testFile);
     }
 
     @Test
@@ -106,7 +127,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.length > 0);
         assertTrue(message.equals(new String(tmp)));
 
-        files.delete(testFile);
+        delete(testFile);
     }
 
     @Test
@@ -125,7 +146,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.length > 0);
         assertTrue(new String(tmp).equals(message + message));
 
-        files.delete(testFile);
+        delete(testFile);
     }
 
     @Test
@@ -147,7 +168,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.length > 0);
         assertTrue(new String(tmp).equals(message));
 
-        files.delete(testFile);
+        delete(testFile);
     }
 
     @Test
@@ -170,7 +191,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.length > 0);
         assertTrue(new String(tmp).equals(message));
 
-        files.delete(testFile);
+        delete(testFile);
     }
 
     @Test
@@ -193,7 +214,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.length > 0);
         assertTrue(new String(tmp).equals(message + message));
 
-        files.delete(testFile);
+        delete(testFile);
     }
 
     @Test
@@ -213,7 +234,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.length > 0);
         assertTrue(new String(tmp).equals(message));
 
-        files.delete(testFile);
+        delete(testFile);
     }
 
     @Test
@@ -237,7 +258,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.length > 0);
         assertTrue(new String(tmp).equals(message));
 
-        files.delete(testFile);
+        delete(testFile);
     }
 
     @Test
@@ -261,7 +282,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.length > 0);
         assertTrue(new String(tmp).equals(message + message));
 
-        files.delete(testFile);
+        delete(testFile);
     }
 
     @Test
@@ -281,7 +302,7 @@ public class RealFileUtilsTest {
         assertNotNull(tmp);
         assertTrue(tmp.equals(message));
 
-        files.delete(testFile);
+        delete(testFile);
     }
 
     @Test
@@ -306,7 +327,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp1.equals("Hello World!"));
         assertTrue(tmp2.equals("Hello World!"));
 
-        files.delete(testFile);
+        delete(testFile);
     }
 
     @Test
@@ -330,7 +351,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp.get(2).equals("line3"));
         assertTrue(tmp.get(3).equals("line4"));
 
-        files.delete(testFile);
+        delete(testFile);
     }
 
     @Test
@@ -357,7 +378,7 @@ public class RealFileUtilsTest {
         assertTrue(tmp2.get(2).equals("line3"));
         assertTrue(tmp2.get(3).equals("line4"));
 
-        files.delete(testFile);
+        delete(testFile);
     }
 
     @SuppressWarnings("CanBeFinal")
@@ -432,11 +453,11 @@ public class RealFileUtilsTest {
         Utils.walkFileTree(files, dirs[0], fv);
 
         for (int i = 0; i < 10; i++) {
-            files.delete(tmp[i]);
+            delete(tmp[i]);
         }
 
-        files.delete(dirs[1]);
-        files.delete(dirs[0]);
+        delete(dirs[1]);
+        delete(dirs[0]);
     }
 
     class MyFileVisitor2 implements FileVisitor {
@@ -486,11 +507,11 @@ public class RealFileUtilsTest {
         Utils.walkFileTree(files, dirs[0], fv);
 
         for (int i = 0; i < 10; i++) {
-            files.delete(tmp[i]);
+            delete(tmp[i]);
         }
 
-        files.delete(dirs[1]);
-        files.delete(dirs[0]);
+        delete(dirs[1]);
+        delete(dirs[0]);
     }
 
     class MyFileVisitor3 implements FileVisitor {
@@ -540,11 +561,11 @@ public class RealFileUtilsTest {
         Utils.walkFileTree(files, dirs[0], fv);
 
         for (int i = 0; i < 10; i++) {
-            files.delete(tmp[i]);
+            delete(tmp[i]);
         }
 
-        files.delete(dirs[1]);
-        files.delete(dirs[0]);
+        delete(dirs[1]);
+        delete(dirs[0]);
     }
 
     class MyFileVisitor4 implements FileVisitor {
@@ -611,12 +632,12 @@ public class RealFileUtilsTest {
         Utils.walkFileTree(files, dirs[0], fv);
 
         for (int i = 0; i < 10; i++) {
-            files.delete(tmp[i]);
+            delete(tmp[i]);
         }
 
-        files.delete(dirs[2]);
-        files.delete(dirs[1]);
-        files.delete(dirs[0]);
+        delete(dirs[2]);
+        delete(dirs[1]);
+        delete(dirs[0]);
     }
 
     class MyFileVisitor5 implements FileVisitor {
@@ -666,11 +687,11 @@ public class RealFileUtilsTest {
         Utils.walkFileTree(files, dirs[0], fv);
 
         for (int i = 0; i < 10; i++) {
-            files.delete(tmp[i]);
+            delete(tmp[i]);
         }
 
-        files.delete(dirs[1]);
-        files.delete(dirs[0]);
+        delete(dirs[1]);
+        delete(dirs[0]);
     }
 
     class MyFileVisitor6 implements FileVisitor {


### PR DESCRIPTION
Fixed directory deletion on windows. As it turns out, having an unclosed directory stream will prevent the deletion of a directory on windows, but not on linux or mac. Utility classes and tests now close directory streams after use.

Also fixed homedir expansion