### PR TITLE
Move utils

### DIFF
--- a/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/RemoteCommandRunner.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/RemoteCommandRunner.java
@@ -17,13 +17,13 @@ package nl.esciencecenter.xenon.adaptors.scripting;
 
 import nl.esciencecenter.xenon.Xenon;
 import nl.esciencecenter.xenon.XenonException;
-import nl.esciencecenter.xenon.engine.util.InputWriter;
-import nl.esciencecenter.xenon.engine.util.OutputReader;
 import nl.esciencecenter.xenon.jobs.Job;
 import nl.esciencecenter.xenon.jobs.JobDescription;
 import nl.esciencecenter.xenon.jobs.JobStatus;
 import nl.esciencecenter.xenon.jobs.Scheduler;
 import nl.esciencecenter.xenon.jobs.Streams;
+import nl.esciencecenter.xenon.util.InputWriter;
+import nl.esciencecenter.xenon.util.OutputReader;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/BatchProcess.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/BatchProcess.java
@@ -26,6 +26,7 @@ import nl.esciencecenter.xenon.files.Path;
 import nl.esciencecenter.xenon.files.RelativePath;
 import nl.esciencecenter.xenon.jobs.JobDescription;
 import nl.esciencecenter.xenon.jobs.Streams;
+import nl.esciencecenter.xenon.util.StreamForwarder;
 import nl.esciencecenter.xenon.util.Utils;
 
 /**

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/CommandRunner.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/CommandRunner.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import nl.esciencecenter.xenon.XenonException;
+import nl.esciencecenter.xenon.util.InputWriter;
+import nl.esciencecenter.xenon.util.OutputReader;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/nl/esciencecenter/xenon/util/InputWriter.java
+++ b/src/main/java/nl/esciencecenter/xenon/util/InputWriter.java
@@ -23,8 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Writes given content to the given output stream. Closes the output stream when done.
- * 
+ * A simple input writer that uses a daemon thread to write from an {#link String} to an {#link OuputStream}. Once the end of the 
+ * string is reached, the destination stream will be closed.
  */
 public final class InputWriter extends Thread {
 
@@ -37,6 +37,12 @@ public final class InputWriter extends Thread {
     // written all content or got exception.
     private boolean finished = false;
 
+    /**
+     * Create a new InputWriter that writes <code>content</code> to the <code>destination</code>.
+     * 
+     * @param content the data to write to the destination.
+     * @param destination the destination to write to.
+     */
     public InputWriter(String content, OutputStream destination) {
         this.destination = destination;
 
@@ -52,10 +58,19 @@ public final class InputWriter extends Thread {
         notifyAll();
     }
 
+    /**
+     * Poll if the InputWriter has finished writing.
+     * 
+     * @return
+     *          if the InputWriter has finished writing.
+     */   
     public synchronized boolean isFinished() {
         return finished;
     }
 
+    /**
+     * Wait until the InputWriter has finished writing.
+     */   
     public synchronized void waitUntilFinished() {
         while (!finished) {
             try {
@@ -66,6 +81,9 @@ public final class InputWriter extends Thread {
         }
     }
 
+    /**
+     * Entry point for the Daemon thread.
+     */    
     public void run() {
         try {
             if (content != null) {

--- a/src/main/java/nl/esciencecenter/xenon/util/InputWriter.java
+++ b/src/main/java/nl/esciencecenter/xenon/util/InputWriter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.esciencecenter.xenon.engine.util;
+package nl.esciencecenter.xenon.util;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/src/main/java/nl/esciencecenter/xenon/util/OutputReader.java
+++ b/src/main/java/nl/esciencecenter/xenon/util/OutputReader.java
@@ -24,7 +24,7 @@ import java.nio.charset.StandardCharsets;
  * A simple output reader that uses a daemon thread to read from an {#link InputStream} and buffer this data. Once end-of-stream
  * is reached, this data will be made available as a {#link String}. 
  * 
- * Note that since the data is buffered in memory, it is not advisable to use this OutputReader to read large amounts of data. 
+ * Note that since the data is buffered in memory, so it is not advisable to use this OutputReader to read large amounts of data. 
  */
 public final class OutputReader extends Thread {
 

--- a/src/main/java/nl/esciencecenter/xenon/util/StreamForwarder.java
+++ b/src/main/java/nl/esciencecenter/xenon/util/StreamForwarder.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A simple stream forwarder that uses a daemon thread to read from an {#link InputStream} and write it to a {#link OuputStream}. 
- * Internally a small buffer is used (typically 1 KB) to improve performance. Any exceptions will be ignored.
+ * A small buffer is used (typically 1 KB) to improve performance. Any exceptions will be ignored.
  */
 public final class StreamForwarder extends Thread {
 

--- a/src/main/java/nl/esciencecenter/xenon/util/StreamForwarder.java
+++ b/src/main/java/nl/esciencecenter/xenon/util/StreamForwarder.java
@@ -1,6 +1,6 @@
 /**
- *
  * Copyright 2013 Netherlands eScience Center
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/nl/esciencecenter/xenon/util/StreamForwarder.java
+++ b/src/main/java/nl/esciencecenter/xenon/util/StreamForwarder.java
@@ -1,6 +1,6 @@
 /**
- * Copyright 2013 Netherlands eScience Center
  *
+ * Copyright 2013 Netherlands eScience Center
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.esciencecenter.xenon.engine.util;
+package nl.esciencecenter.xenon.util;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -24,9 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * 
- * Simple stream forwarder. Uses a daemon thread to read and write data, has a small buffer, and ignores all exceptions.
- * 
+ * A simple stream forwarder that uses a daemon thread to read from an {#link InputStream} and write it to a {#link OuputStream}. 
+ * Internally a small buffer is used (typically 1 KB) to improve performance. Any exceptions will be ignored.
  */
 public final class StreamForwarder extends Thread {
 
@@ -39,6 +38,12 @@ public final class StreamForwarder extends Thread {
 
     private boolean done = false;
     
+    /**
+     * Create a new StreamForwarder and start it immediately.
+     * 
+     * @param in the {#link InputStream} to read from.
+     * @param out the {#link OuputStream} to write to.
+     */
     public StreamForwarder(InputStream in, OutputStream out) {
         this.in = in;
         this.out = out;
@@ -50,6 +55,9 @@ public final class StreamForwarder extends Thread {
 
     /**
      * Closes the input stream, thereby stopping the stream forwarder, and closing the output stream.
+     * 
+     * @param c The {#link Closable} to close (i.e., the {#link InputStream} or {#link OutputStream}) 
+     * @param error The error message to print if the close results in an Exception
      */
     private void close(Closeable c, String error) {
         try {
@@ -61,11 +69,21 @@ public final class StreamForwarder extends Thread {
         }
     }
 
+    /**
+     * Tell the daemon thread that we are done.
+     */
     private synchronized void done() {
         done = true;
         notifyAll();
     }
     
+    /**
+     * Wait for a given timeout for the StreamForwarder to terminate by reading an end-of-stream on the input. When the timeout
+     * expires both input and output streams will be closed, regardless of whether the input has reached end-of-line.
+     * 
+     * @param timeout
+     *          The number of milliseconds to wait for termination. 
+     */
     public synchronized void terminate(long timeout) { 
 
         if (done) { 
@@ -97,6 +115,9 @@ public final class StreamForwarder extends Thread {
         }
     }
     
+    /**
+     * Main entry method for the daemon thread.
+     */
     public void run() {
         try {
             byte[] buffer = new byte[BUFFER_SIZE];


### PR DESCRIPTION
Moved several simple utility classes from `xenon.engine.util` to `xenon.util` to allow re-use by applications that use xenon.