### PR TITLE
Hotfix wait

### DIFF
--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/GenericJobAdaptorTestParent.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/GenericJobAdaptorTestParent.java
@@ -25,7 +25,16 @@ import static org.junit.Assert.fail;
 import java.util.HashMap;
 import java.util.Map;
 
-import nl.esciencecenter.xenon.InvalidCredentialException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.junit.runners.MethodSorters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import nl.esciencecenter.xenon.InvalidLocationException;
 import nl.esciencecenter.xenon.InvalidPropertyException;
 import nl.esciencecenter.xenon.UnknownPropertyException;
@@ -45,16 +54,6 @@ import nl.esciencecenter.xenon.jobs.NoSuchSchedulerException;
 import nl.esciencecenter.xenon.jobs.QueueStatus;
 import nl.esciencecenter.xenon.jobs.Scheduler;
 import nl.esciencecenter.xenon.util.Utils;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestWatcher;
-import org.junit.runners.MethodSorters;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/GenericScheduleJobTestParent.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/GenericScheduleJobTestParent.java
@@ -1005,7 +1005,7 @@ public abstract class GenericScheduleJobTestParent {
 
     @Test
     public void test46a_batchJobSubmitWithPollingWaitUntilDone() throws Exception {
-        String workingDir = getWorkingDir("test46");
+        String workingDir = getWorkingDir("test46a");
         Path root = initJobDirectory(workingDir);
 
         try {
@@ -1017,7 +1017,7 @@ public abstract class GenericScheduleJobTestParent {
 
             JobStatus status = jobs.waitUntilDone(job, 1000);
             
-            while (status.isRunning()) {
+            while (!status.isDone()) {
                 status = jobs.waitUntilDone(job, 1000);
             }
             
@@ -1035,7 +1035,7 @@ public abstract class GenericScheduleJobTestParent {
 
     @Test
     public void test46b_batchJobSubmitWithPollingWaitUntilDone() throws Exception {
-        String workingDir = getWorkingDir("test46");
+        String workingDir = getWorkingDir("test46b");
         Path root = initJobDirectory(workingDir);
 
         try {
@@ -1046,7 +1046,7 @@ public abstract class GenericScheduleJobTestParent {
             JobStatus status = jobs.waitUntilDone(job, 1000);
             int count = 1;
             
-            while (status.isRunning()) {
+            while (!status.isDone()) {
                 status = jobs.waitUntilDone(job, 1000);
                 count++;
             }
@@ -1064,7 +1064,7 @@ public abstract class GenericScheduleJobTestParent {
     
     @Test
     public void test46c_batchJobSubmitWithPollingWaitUntilDone() throws Exception {
-        String workingDir = getWorkingDir("test46");
+        String workingDir = getWorkingDir("test46c");
         Path root = initJobDirectory(workingDir);
 
         try {
@@ -1074,7 +1074,7 @@ public abstract class GenericScheduleJobTestParent {
 
             JobStatus status = jobs.waitUntilDone(job, 1000);
             
-            while (status.isRunning()) {
+            while (!status.isDone()) {
                 long now = System.currentTimeMillis();
                 
                 status = jobs.waitUntilDone(job, 1000);
@@ -1096,7 +1096,7 @@ public abstract class GenericScheduleJobTestParent {
     
     @Test
     public void test47_batchJobSubmitWithSingleWaitUntilDone() throws Exception {
-        String workingDir = getWorkingDir("test46");
+        String workingDir = getWorkingDir("test47");
         Path root = initJobDirectory(workingDir);
 
         try {
@@ -1124,7 +1124,7 @@ public abstract class GenericScheduleJobTestParent {
     
     @Test
     public void test48_batchJobSubmitWithSingleWaitUntilRunning() throws Exception {
-        String workingDir = getWorkingDir("test46");
+        String workingDir = getWorkingDir("test48");
         Path root = initJobDirectory(workingDir);
 
         try {
@@ -1149,7 +1149,7 @@ public abstract class GenericScheduleJobTestParent {
 
     @Test(expected = IllegalArgumentException.class)
     public void test49_batchJobSubmitWithIllegalWaitUntilDone() throws Exception {
-        String workingDir = getWorkingDir("test46");
+        String workingDir = getWorkingDir("test49");
         Path root = initJobDirectory(workingDir);
 
         try {

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/GenericScheduleJobTestParent.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/GenericScheduleJobTestParent.java
@@ -981,4 +981,27 @@ public abstract class GenericScheduleJobTestParent {
             cleanupJob(job, root, stdin);
         }
     }
+    
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void test45_batchJobSubmitWithIllegalWait() throws Exception {
+        String workingDir = getWorkingDir("test45");
+        Path root = initJobDirectory(workingDir);
+
+        try {
+            JobDescription description = timedJobDescription(workingDir, 60000);
+            description.setStdout("stdout.txt");
+            description.setStderr("stderr.txt");
+
+            job = jobs.submitJob(scheduler, description);
+
+            // Should throw exception
+            jobs.waitUntilRunning(job, -1);
+        } finally {
+            jobs.cancelJob(job);
+            jobs.waitUntilDone(job, 0);
+            cleanupJob(job, root);
+        }
+    }
+
 }

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/GenericScheduleJobTestParent.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/GenericScheduleJobTestParent.java
@@ -989,7 +989,7 @@ public abstract class GenericScheduleJobTestParent {
         Path root = initJobDirectory(workingDir);
 
         try {
-            JobDescription description = timedJobDescription(workingDir, 60000);
+            JobDescription description = timedJobDescription(workingDir, 5);
             description.setStdout("stdout.txt");
             description.setStderr("stderr.txt");
 
@@ -1010,7 +1010,7 @@ public abstract class GenericScheduleJobTestParent {
         Path root = initJobDirectory(workingDir);
 
         try {
-            JobDescription description = timedJobDescription(workingDir, 10000);
+            JobDescription description = timedJobDescription(workingDir, 10);
             
             long start = System.currentTimeMillis();
             
@@ -1040,7 +1040,7 @@ public abstract class GenericScheduleJobTestParent {
         Path root = initJobDirectory(workingDir);
 
         try {
-            JobDescription description = timedJobDescription(workingDir, 10000);
+            JobDescription description = timedJobDescription(workingDir, 10);
             
             job = jobs.submitJob(scheduler, description);
 
@@ -1069,7 +1069,7 @@ public abstract class GenericScheduleJobTestParent {
         Path root = initJobDirectory(workingDir);
 
         try {
-            JobDescription description = timedJobDescription(workingDir, 10000);
+            JobDescription description = timedJobDescription(workingDir, 10);
             
             job = jobs.submitJob(scheduler, description);
 
@@ -1101,7 +1101,7 @@ public abstract class GenericScheduleJobTestParent {
         Path root = initJobDirectory(workingDir);
 
         try {
-            JobDescription description = timedJobDescription(workingDir, 10000);
+            JobDescription description = timedJobDescription(workingDir, 10);
             
             long start = System.currentTimeMillis();
             
@@ -1129,7 +1129,7 @@ public abstract class GenericScheduleJobTestParent {
         Path root = initJobDirectory(workingDir);
 
         try {
-            JobDescription description = timedJobDescription(workingDir, 5000);
+            JobDescription description = timedJobDescription(workingDir, 5);
             
             job = jobs.submitJob(scheduler, description);
 
@@ -1154,7 +1154,7 @@ public abstract class GenericScheduleJobTestParent {
         Path root = initJobDirectory(workingDir);
 
         try {
-            JobDescription description = timedJobDescription(workingDir, 1000);
+            JobDescription description = timedJobDescription(workingDir, 1);
             
             job = jobs.submitJob(scheduler, description);
 

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/GenericScheduleJobTestParent.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/GenericScheduleJobTestParent.java
@@ -1004,4 +1004,67 @@ public abstract class GenericScheduleJobTestParent {
         }
     }
 
+    @Test
+    public void test46_batchJobSubmitWithPollingWait() throws Exception {
+        String workingDir = getWorkingDir("test46");
+        Path root = initJobDirectory(workingDir);
+
+        try {
+            JobDescription description = timedJobDescription(workingDir, 10000);
+            
+            long start = System.currentTimeMillis();
+            
+            job = jobs.submitJob(scheduler, description);
+
+            JobStatus status = jobs.waitUntilDone(job, 1000);
+            int count = 1;
+            
+            while (status.isRunning()) {
+                status = jobs.waitUntilDone(job, 1000);
+                count++;
+            }
+            
+            long end = System.currentTimeMillis(); 
+            
+            checkJobDone(status);
+            
+            // We expect the job to have lasted at least 10000 milliseconds, which would require 9 or more times polling.
+            assertTrue((end-start) >= 10000);
+            assertTrue(count >= 9);
+            
+        } finally {
+            cleanupJob(job, root);
+        }
+    }
+
+    @Test
+    public void test76_batchJobSubmitWithSingleWait() throws Exception {
+        String workingDir = getWorkingDir("test46");
+        Path root = initJobDirectory(workingDir);
+
+        try {
+            JobDescription description = timedJobDescription(workingDir, 10000);
+            
+            long start = System.currentTimeMillis();
+            
+            job = jobs.submitJob(scheduler, description);
+
+            // Should wait until the job is finished, however long it takes.
+            JobStatus status = jobs.waitUntilDone(job, 0);
+            
+            long end = System.currentTimeMillis(); 
+            
+            // Job must be in done state
+            checkJobDone(status);
+            
+            // We expect the job to have lasted at least 10000 milliseconds, which would require 9 or more times polling.
+            assertTrue((end-start) >= 10000);
+            
+        } finally {
+            cleanupJob(job, root);
+        }
+    }
+    
+    
+    
 }

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/GenericScheduleJobTestParent.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/GenericScheduleJobTestParent.java
@@ -998,7 +998,6 @@ public abstract class GenericScheduleJobTestParent {
             // Should throw exception
             jobs.waitUntilRunning(job, -1);
         } finally {
-            jobs.cancelJob(job);
             jobs.waitUntilDone(job, 0);
             cleanupJob(job, root);
         }
@@ -1163,7 +1162,6 @@ public abstract class GenericScheduleJobTestParent {
             
         } finally {
             jobs.cancelJob(job);
-            jobs.waitUntilDone(job, 0);
             cleanupJob(job, root);
         }
     }

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/JobQueues.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/JobQueues.java
@@ -270,10 +270,6 @@ public class JobQueues {
     public JobStatus waitUntilDone(Job job, long timeout) throws XenonException {
         LOGGER.debug("{}: Waiting for job {} for {} ms.", adaptorName, job.getIdentifier(), timeout);
 
-        if (timeout < 0) {
-            throw new XenonException(adaptorName, "Illegal timeout " + timeout);
-        }
-
         checkScheduler(job.getScheduler());
 
         List<JobExecutor> queue = findQueue(job.getJobDescription().getQueueName());

--- a/src/main/java/nl/esciencecenter/xenon/engine/util/JobQueues.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/util/JobQueues.java
@@ -293,17 +293,13 @@ public class JobQueues {
 
         LOGGER.debug("{}: Waiting for job {} to start for {} ms.", adaptorName, job.getIdentifier(), timeout);
 
-        if (timeout < 0) {
-            throw new XenonException(adaptorName, "Illegal timeout " + timeout);
-        }
-
         checkScheduler(job.getScheduler());
 
         List<JobExecutor> queue = findQueue(job.getJobDescription().getQueueName());
         JobStatus status = findJob(queue, job).waitUntilRunning(timeout);
 
         if (status.isDone()) {
-            LOGGER.debug("{}: Job {} is done after {} ms.", adaptorName, job.getIdentifier(), timeout);
+            LOGGER.debug("{}: Job {} is done within {} ms.", adaptorName, job.getIdentifier(), timeout);
             cleanupJob(queue, job);
         } else {
             LOGGER.debug("{}: Job {} is NOT done after {} ms.", adaptorName, job.getIdentifier(), timeout);

--- a/src/main/java/nl/esciencecenter/xenon/jobs/Jobs.java
+++ b/src/main/java/nl/esciencecenter/xenon/jobs/Jobs.java
@@ -271,11 +271,12 @@ public interface Jobs {
     /**
      * Wait until a job is done or until a timeout expires.
      * <p>
-     * This method will wait until a job is done, killed, or produces an error, or until a timeout expires. If the timeout
-     * expires, the job will continue to run normally.
+     * This method will wait until a job is done (either gracefully or by being killed or producing an error), or until the 
+     * timeout expires, whichever comes first. If the timeout expires, the job will continue to run.
      * </p>
      * <p>
-     * The timeout is in milliseconds and must be &gt;= 0, where 0 means an infinite timeout.
+     * The timeout is in milliseconds and must be &gt;= 0. When timeout is 0, it will be ignored and this method will wait until
+     * the jobs is done.  
      * </p>
      * <p>
      * A JobStatus is returned that can be used to determine why the call returned.
@@ -296,14 +297,15 @@ public interface Jobs {
     JobStatus waitUntilDone(Job job, long timeout) throws XenonException;
 
     /**
-     * Wait for as long a job is waiting in a queue, or until a timeout expires.
+     * Wait while a job is waiting in a queue, or until a timeout expires.
      * <p>
-     * This method will return as soon as the job is no longer waiting in the queue or when the timeout expires, whichever comes
-     * first. If the job is no longer waiting in the queue, it may be running, but it may also be killed, finished or produce 
+     * This method will return as soon as the job is no longer waiting in the queue, or when the timeout expires, whichever comes
+     * first. If the job is no longer waiting in the queue, it may be running, but it may also be killed, finished or produced 
      * an error. If the timeout expires, the job will continue to be queued normally.
      * </p>
      * <p>
-     * The timeout is in milliseconds and must be &gt;= 0, where 0 means an infinite timeout.
+     * The timeout is in milliseconds and must be &gt;= 0. When timeout is 0, it will be ignored and this method will wait until
+     * the job is no longer queued.  
      * </p>
      * <p>
      * A JobStatus is returned that can be used to determine why the call returned.

--- a/src/main/java/nl/esciencecenter/xenon/jobs/Jobs.java
+++ b/src/main/java/nl/esciencecenter/xenon/jobs/Jobs.java
@@ -286,6 +286,8 @@ public interface Jobs {
      *            the maximum time to wait for the job in milliseconds.
      * @return the status of the Job.
      * 
+     * @throws IllegalArgumentException 
+     *             If the value of timeout is negative
      * @throws NoSuchJobException
      *             If the job is not known.
      * @throws XenonException
@@ -296,9 +298,9 @@ public interface Jobs {
     /**
      * Wait for as long a job is waiting in a queue, or until a timeout expires.
      * <p>
-     * This method will return as soon as the job is no longer waiting in the queue. This is generally the case when it starts
-     * running, but it may also be killed or produce an error. If the timeout expires, the job will continue to be queued
-     * normally.
+     * This method will return as soon as the job is no longer waiting in the queue or when the timeout expires, whichever comes
+     * first. If the job is no longer waiting in the queue, it may be running, but it may also be killed, finished or produce 
+     * an error. If the timeout expires, the job will continue to be queued normally.
      * </p>
      * <p>
      * The timeout is in milliseconds and must be &gt;= 0, where 0 means an infinite timeout.
@@ -312,6 +314,8 @@ public interface Jobs {
      *            the maximum time to wait in milliseconds.
      * @return the status of the Job.
      * 
+     * @throws IllegalArgumentException 
+     *             If the value of timeout is negative
      * @throws NoSuchJobException
      *             If the job is not known.
      * @throws XenonException

--- a/src/test/java/nl/esciencecenter/xenon/engine/util/JobQueueTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/util/JobQueueTest.java
@@ -58,8 +58,8 @@ public class JobQueueTest {
     static class MyProcessWrapper implements InteractiveProcess {
 
         private final JobImplementation job;
-        private final byte[] output;
         private final byte[] error;
+        private final byte[] output;
 
         private boolean destroyed = false;
         private boolean done = false;
@@ -322,7 +322,7 @@ public class JobQueueTest {
         }
     }
 
-    @Test(expected = XenonException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void test_invalidWaitTimeout() throws Exception {
         // throws exception
         jobQueue.waitUntilDone(mock(Job.class), -42);


### PR DESCRIPTION
Created consistent behavior for `Jobs.waitUntilDone` and `Jobs.waitUntilRunning` between the different adaptors and matching with the Javadoc. Fixes #413  