### PR TITLE
Schemesplit

### DIFF
--- a/src/main/java/nl/esciencecenter/xenon/AdaptorStatus.java
+++ b/src/main/java/nl/esciencecenter/xenon/AdaptorStatus.java
@@ -26,6 +26,21 @@ import java.util.Map;
 public interface AdaptorStatus {
 
     /**
+     * Get the supported job submission schemes for this adaptor.
+     * 
+     * @return the schemes supported by this adaptor.
+     */
+    String[] getSupportedJobSchemes();
+
+    
+    /**
+     * Get the supported file access schemes for this adaptor.
+     * 
+     * @return the schemes supported by this adaptor.
+     */
+    String[] getSupportedFileSchemes();
+    
+    /**
      * Get the supported schemes for this adaptor.
      * 
      * @return the schemes supported by this adaptor.

--- a/src/main/java/nl/esciencecenter/xenon/AdaptorStatus.java
+++ b/src/main/java/nl/esciencecenter/xenon/AdaptorStatus.java
@@ -31,7 +31,6 @@ public interface AdaptorStatus {
      * @return the schemes supported by this adaptor.
      */
     String[] getSupportedJobSchemes();
-
     
     /**
      * Get the supported file access schemes for this adaptor.

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpAdaptor.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpAdaptor.java
@@ -44,7 +44,7 @@ public class FtpAdaptor extends Adaptor {
     private static final String ADAPTOR_DESCRIPTION = "The FTP adaptor implements all functionality with remote ftp servers.";
 
     /** The schemes supported by this adaptor */
-    protected static final ImmutableArray<String> ADAPTOR_SCHEME = new ImmutableArray<>("ftp");
+    protected static final ImmutableArray<String> ADAPTOR_FILE_SCHEME = new ImmutableArray<>("ftp");
 
     /** The locations supported by this adaptor */
     private static final ImmutableArray<String> ADAPTOR_LOCATIONS = new ImmutableArray<>("[user@]host[:port]");
@@ -107,7 +107,7 @@ public class FtpAdaptor extends Adaptor {
     private final FtpCredentials credentialsAdaptor;
 
     public FtpAdaptor(XenonEngine xenonEngine, Map<String, String> properties) throws XenonException {
-        super(xenonEngine, ADAPTOR_NAME, ADAPTOR_DESCRIPTION, ADAPTOR_SCHEME, ADAPTOR_LOCATIONS, VALID_PROPERTIES,
+        super(xenonEngine, ADAPTOR_NAME, ADAPTOR_DESCRIPTION, null, ADAPTOR_FILE_SCHEME, ADAPTOR_LOCATIONS, VALID_PROPERTIES,
                 new XenonProperties(VALID_PROPERTIES, Component.XENON, properties));
 
         filesAdaptor = new FtpFiles(this, xenonEngine);

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpFiles.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpFiles.java
@@ -135,7 +135,12 @@ public class FtpFiles implements Files {
         login(credential, ftpClient);
         return createAndRegisterFileSystem(scheme, location, credential, xenonProperties, ftpClient);
     }
-
+    
+    @Override
+    public String [] getSupportedSchemes() throws XenonException { 
+        return adaptor.getSupportedFileSchemes();
+    }
+    
     private FileSystemImplementation createAndRegisterFileSystem(String scheme, String location, Credential credential,
             XenonProperties xenonProperties, FTPClient ftpClient) throws XenonException {
         String cwd = getCurrentWorkingDirectory(ftpClient);

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpLocation.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ftp/FtpLocation.java
@@ -25,7 +25,7 @@ public class FtpLocation extends Location {
     }
 
     protected FtpLocation(String location) throws InvalidLocationException {
-        super(location, FtpAdaptor.ADAPTOR_SCHEME.get(0));
+        super(location, FtpAdaptor.ADAPTOR_FILE_SCHEME.get(0));
     }
 
     @Override

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineAdaptor.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/gridengine/GridEngineAdaptor.java
@@ -44,7 +44,7 @@ public class GridEngineAdaptor extends ScriptingAdaptor {
     public static final String PREFIX = XenonEngine.ADAPTORS_PREFIX + GridEngineAdaptor.ADAPTOR_NAME + ".";
 
     /** The schemes supported by this adaptor */
-    private static final ImmutableArray<String> ADAPTOR_SCHEMES = new ImmutableArray<>("ge", "sge");
+    private static final ImmutableArray<String> ADAPTOR_JOB_SCHEMES = new ImmutableArray<>("ge", "sge");
     
     /** The locations supported by this adaptor */
     private static final ImmutableArray<String> ADAPTOR_LOCATIONS = new ImmutableArray<>("(locations supported by local)",
@@ -86,7 +86,7 @@ public class GridEngineAdaptor extends ScriptingAdaptor {
      *             if the adaptor creation fails.
      */
     public GridEngineAdaptor(XenonEngine xenonEngine, Map<String, String> properties) throws XenonException {
-        super(xenonEngine, ADAPTOR_NAME, ADAPTOR_DESCRIPTION, ADAPTOR_SCHEMES, ADAPTOR_LOCATIONS, VALID_PROPERTIES, 
+        super(xenonEngine, ADAPTOR_NAME, ADAPTOR_DESCRIPTION, ADAPTOR_JOB_SCHEMES, null, ADAPTOR_LOCATIONS, VALID_PROPERTIES, 
                 new XenonProperties(VALID_PROPERTIES, Component.XENON, properties), new GridEngineSchedulerConnectionFactory());
     }
 

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalAdaptor.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalAdaptor.java
@@ -77,8 +77,11 @@ public class LocalAdaptor extends Adaptor {
     /** How many jobs have been submitted locally. */
     public static final String SUBMITTED = JOBS + "submitted";
     
-    /** The schemes supported by the adaptor */
-    private static final ImmutableArray<String> ADAPTOR_SCHEME = new ImmutableArray<>("local", "file");
+    /** The job schemes supported by the adaptor */
+    private static final ImmutableArray<String> ADAPTOR_JOB_SCHEME = new ImmutableArray<>("local");
+
+    /** The file schemes supported by the adaptor */
+    private static final ImmutableArray<String> ADAPTOR_FILE_SCHEME = new ImmutableArray<>("file");
 
     /** The locations supported by the adaptor */
     private static final ImmutableArray<String> ADAPTOR_LOCATIONS = new ImmutableArray<>("(null)", "(empty string)", "/");
@@ -101,8 +104,8 @@ public class LocalAdaptor extends Adaptor {
     private final LocalCredentials localCredentials;
 
     public LocalAdaptor(XenonEngine xenonEngine, Map<String, String> properties) throws XenonException {
-        super(xenonEngine, ADAPTOR_NAME, ADAPTOR_DESCRIPTION, ADAPTOR_SCHEME, ADAPTOR_LOCATIONS, VALID_PROPERTIES, 
-                new XenonProperties(VALID_PROPERTIES, Component.XENON, properties));
+        super(xenonEngine, ADAPTOR_NAME, ADAPTOR_DESCRIPTION, ADAPTOR_JOB_SCHEME, ADAPTOR_FILE_SCHEME, ADAPTOR_LOCATIONS, 
+                VALID_PROPERTIES, new XenonProperties(VALID_PROPERTIES, Component.XENON, properties));
 
         localFiles = new LocalFiles(this, xenonEngine.getCopyEngine());
         localJobs = new LocalJobs(this, getProperties(), Utils.getLocalCWD(localFiles), xenonEngine);

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalFiles.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/local/LocalFiles.java
@@ -46,7 +46,7 @@ import nl.esciencecenter.xenon.util.Utils;
 public class LocalFiles implements Files {
 
     /** The parent adaptor */
-    private final LocalAdaptor localAdaptor;
+    private final LocalAdaptor adaptor;
 
     /** The copy engine */
     private final CopyEngine copyEngine;
@@ -59,7 +59,7 @@ public class LocalFiles implements Files {
     }
 
     public LocalFiles(LocalAdaptor localAdaptor, CopyEngine copyEngine) {
-        this.localAdaptor = localAdaptor;
+        this.adaptor = localAdaptor;
         this.copyEngine = copyEngine;
     }
 
@@ -102,6 +102,11 @@ public class LocalFiles implements Files {
         }
 
         throw new InvalidLocationException(LocalAdaptor.ADAPTOR_NAME, "Location must only contain a file system root! (not " + location + ")");
+    }
+    
+    @Override
+    public String [] getSupportedSchemes() throws XenonException { 
+        return adaptor.getSupportedFileSchemes();
     }
     
     /**
@@ -271,9 +276,9 @@ public class LocalFiles implements Files {
             throws XenonException {
         checkFileLocation(location);
 
-        localAdaptor.checkCredential(credential);
+        adaptor.checkCredential(credential);
 
-        XenonProperties p = new XenonProperties(localAdaptor.getSupportedProperties(Component.FILESYSTEM), properties);
+        XenonProperties p = new XenonProperties(adaptor.getSupportedProperties(Component.FILESYSTEM), properties);
 
         String root = Utils.getLocalRoot(location);
         RelativePath relativePath = new RelativePath(root).relativize(new RelativePath(location));

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/ScriptingAdaptor.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/ScriptingAdaptor.java
@@ -41,11 +41,12 @@ public abstract class ScriptingAdaptor extends Adaptor {
     private final ForwardingCredentials credentialsAdaptor;
 
     protected ScriptingAdaptor(XenonEngine xenonEngine, String name, String description, 
-            ImmutableArray<String> supportedSchemes, ImmutableArray<String> supportedLocations, 
-            ImmutableArray<XenonPropertyDescription> validProperties, 
+            ImmutableArray<String> supportedJobSchemes, ImmutableArray<String> supportedFileSchemes, 
+            ImmutableArray<String> supportedLocations, ImmutableArray<XenonPropertyDescription> validProperties, 
             XenonProperties properties, SchedulerConnectionFactory factory) throws XenonException {
 
-        super(xenonEngine, name, description, supportedSchemes, supportedLocations, validProperties, properties);
+        super(xenonEngine, name, description, supportedJobSchemes, supportedFileSchemes, supportedLocations, validProperties, 
+                properties);
 
         jobsAdaptor = new ScriptingJobs(this, xenonEngine, factory);
         credentialsAdaptor = new ForwardingCredentials(xenonEngine, "ssh");

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/ScriptingJobs.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/scripting/ScriptingJobs.java
@@ -18,6 +18,7 @@ package nl.esciencecenter.xenon.adaptors.scripting;
 import java.util.Collection;
 import java.util.Map;
 
+import nl.esciencecenter.xenon.InvalidSchemeException;
 import nl.esciencecenter.xenon.XenonException;
 import nl.esciencecenter.xenon.XenonPropertyDescription.Component;
 import nl.esciencecenter.xenon.XenonRuntimeException;
@@ -113,6 +114,41 @@ public class ScriptingJobs implements Jobs {
         return connection.getScheduler();
     }
 
+    @Override
+    public String [] getSupportedSchemes() throws XenonException { 
+        return adaptor.getSupportedJobSchemes();
+    }
+    
+    @Override
+    public boolean isOnline(String scheme) throws XenonException {
+        
+        if (!adaptor.supportsJob(scheme)) { 
+            throw new InvalidSchemeException(adaptor.getName(), scheme);
+        }
+        
+        return true;
+    }
+    
+    @Override
+    public boolean supportsInteractive(String scheme) throws XenonException { 
+        
+        if (!adaptor.supportsJob(scheme)) { 
+            throw new InvalidSchemeException(adaptor.getName(), scheme);
+        }
+        
+        return true;
+    }
+
+    @Override
+    public boolean supportsBatch(String scheme) throws XenonException { 
+
+        if (!adaptor.supportsJob(scheme)) { 
+            throw new InvalidSchemeException(adaptor.getName(), scheme);
+        }
+
+        return true;
+    }
+    
     @Override
     public String getDefaultQueueName(Scheduler scheduler) throws XenonException {
         //find connection

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmAdaptor.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/slurm/SlurmAdaptor.java
@@ -44,7 +44,7 @@ public class SlurmAdaptor extends ScriptingAdaptor {
     public static final String PREFIX = XenonEngine.ADAPTORS_PREFIX + SlurmAdaptor.ADAPTOR_NAME + ".";
 
     /** The schemes supported by this adaptor */
-    private static final ImmutableArray<String> ADAPTOR_SCHEMES = new ImmutableArray<>("slurm");
+    private static final ImmutableArray<String> ADAPTOR_JOB_SCHEMES = new ImmutableArray<>("slurm");
     
     /** The locations supported by this adaptor */
     private static final ImmutableArray<String> ADAPTOR_LOCATIONS = new ImmutableArray<>("(locations supported by local)",
@@ -87,7 +87,7 @@ public class SlurmAdaptor extends ScriptingAdaptor {
      *             if the adaptor creation fails.
      */
     public SlurmAdaptor(XenonEngine xenonEngine, Map<String, String> properties) throws XenonException {
-        super(xenonEngine, ADAPTOR_NAME, ADAPTOR_DESCRIPTION, ADAPTOR_SCHEMES, ADAPTOR_LOCATIONS, VALID_PROPERTIES, 
+        super(xenonEngine, ADAPTOR_NAME, ADAPTOR_DESCRIPTION, ADAPTOR_JOB_SCHEMES, null, ADAPTOR_LOCATIONS, VALID_PROPERTIES, 
                 new XenonProperties(VALID_PROPERTIES, Component.XENON, properties), new SlurmSchedulerConnectionFactory());
     }
 

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshAdaptor.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshAdaptor.java
@@ -62,9 +62,12 @@ public class SshAdaptor extends Adaptor {
     /** A description of this adaptor */
     private static final String ADAPTOR_DESCRIPTION = "The SSH adaptor implements all functionality with remote ssh servers.";
 
-    /** The schemes supported by this adaptor */
-    protected static final ImmutableArray<String> ADAPTOR_SCHEME = new ImmutableArray<>("ssh", "sftp");
+    /** The job schemes supported by this adaptor */
+    protected static final ImmutableArray<String> ADAPTOR_JOB_SCHEME = new ImmutableArray<>("ssh");
 
+    /** The file schemes supported by this adaptor */
+    protected static final ImmutableArray<String> ADAPTOR_FILE_SCHEME = new ImmutableArray<>("sftp");
+    
     /** The locations supported by this adaptor */
     private static final ImmutableArray<String> ADAPTOR_LOCATIONS = new ImmutableArray<>("[user@]host[:port]");
 
@@ -159,8 +162,8 @@ public class SshAdaptor extends Adaptor {
     }
 
     public SshAdaptor(XenonEngine xenonEngine, JSch jsch, Map<String, String> properties) throws XenonException {
-        super(xenonEngine, ADAPTOR_NAME, ADAPTOR_DESCRIPTION, ADAPTOR_SCHEME, ADAPTOR_LOCATIONS, VALID_PROPERTIES,
-                new XenonProperties(VALID_PROPERTIES, Component.XENON, properties));
+        super(xenonEngine, ADAPTOR_NAME, ADAPTOR_DESCRIPTION, ADAPTOR_JOB_SCHEME, ADAPTOR_FILE_SCHEME, ADAPTOR_LOCATIONS,
+                VALID_PROPERTIES, new XenonProperties(VALID_PROPERTIES, Component.XENON, properties));
 
         this.filesAdaptor = new SshFiles(this, xenonEngine);
         this.jobsAdaptor = new SshJobs(getProperties(), this, xenonEngine);

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshFiles.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshFiles.java
@@ -188,7 +188,12 @@ public class SshFiles implements Files {
 
         return newFileSystem(session, scheme, location, credential, xenonProperties);
     }
-
+    
+    @Override
+    public String [] getSupportedSchemes() throws XenonException { 
+        return adaptor.getSupportedFileSchemes();
+    }
+    
     private SshMultiplexedSession getSession(Path path) throws XenonException {
 
         FileSystemImplementation fs = (FileSystemImplementation) path.getFileSystem();

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshJobs.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshJobs.java
@@ -18,6 +18,7 @@ package nl.esciencecenter.xenon.adaptors.ssh;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import nl.esciencecenter.xenon.InvalidSchemeException;
 import nl.esciencecenter.xenon.XenonException;
 import nl.esciencecenter.xenon.XenonPropertyDescription.Component;
 import nl.esciencecenter.xenon.credentials.Credential;
@@ -130,7 +131,41 @@ public class SshJobs implements Jobs {
 
         return scheduler;
     }
+    
+    @Override
+    public String [] getSupportedSchemes() throws XenonException { 
+        return adaptor.getSupportedJobSchemes();
+    }
+    
+    @Override
+    public boolean isOnline(String scheme) throws XenonException {
+        
+        if (!adaptor.supportsJob(scheme)) { 
+            throw new InvalidSchemeException(adaptor.getName(), scheme);
+        }
+        
+        return true;
+    }
+    
+    @Override
+    public boolean supportsInteractive(String scheme) throws XenonException { 
+        if (!adaptor.supportsJob(scheme)) { 
+            throw new InvalidSchemeException(adaptor.getName(), scheme);
+        }
+        
+        return true;
+    }
 
+    @Override
+    public boolean supportsBatch(String scheme) throws XenonException { 
+
+        if (!adaptor.supportsJob(scheme)) { 
+            throw new InvalidSchemeException(adaptor.getName(), scheme);
+        }
+
+        return true;
+    }
+    
     private JobQueues getJobQueue(Scheduler scheduler) throws XenonException {
 
         if (!(scheduler instanceof SchedulerImplementation)) {

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshLocation.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/ssh/SshLocation.java
@@ -27,7 +27,7 @@ public class SshLocation extends Location {
     }
 
     protected SshLocation(String location) throws InvalidLocationException {
-        super(location, SshAdaptor.ADAPTOR_SCHEME.get(0));
+        super(location, SshAdaptor.ADAPTOR_JOB_SCHEME.get(0));
     }
 
     @Override

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/torque/TorqueAdaptor.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/torque/TorqueAdaptor.java
@@ -44,7 +44,7 @@ public class TorqueAdaptor extends ScriptingAdaptor {
     public static final String PREFIX = XenonEngine.ADAPTORS_PREFIX + TorqueAdaptor.ADAPTOR_NAME + ".";
 
     /** The schemes supported by this adaptor */
-    private static final ImmutableArray<String> ADAPTOR_SCHEMES = new ImmutableArray<>("torque");
+    private static final ImmutableArray<String> ADAPTOR_JOB_SCHEMES = new ImmutableArray<>("torque");
     
     /** The locations supported by this adaptor */
     private static final ImmutableArray<String> ADAPTOR_LOCATIONS = new ImmutableArray<>("(locations supported by local)", 
@@ -86,7 +86,7 @@ public class TorqueAdaptor extends ScriptingAdaptor {
      *             if the adaptor creation fails.
      */
     public TorqueAdaptor(XenonEngine xenonEngine, Map<String, String> properties) throws XenonException {
-        super(xenonEngine, ADAPTOR_NAME, ADAPTOR_DESCRIPTION, ADAPTOR_SCHEMES, ADAPTOR_LOCATIONS, VALID_PROPERTIES, 
+        super(xenonEngine, ADAPTOR_NAME, ADAPTOR_DESCRIPTION, ADAPTOR_JOB_SCHEMES, null, ADAPTOR_LOCATIONS, VALID_PROPERTIES, 
                 new XenonProperties(VALID_PROPERTIES, Component.XENON, properties), new TorqueSchedulerConnectionFactory());
     }
 

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/webdav/WebdavAdaptor.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/webdav/WebdavAdaptor.java
@@ -44,7 +44,7 @@ public class WebdavAdaptor extends Adaptor {
     private static final String ADAPTOR_DESCRIPTION = "The webdav adaptor implements all functionality with remote webdav servers.";
 
     /** The schemes supported by this adaptor */
-    protected static final ImmutableArray<String> ADAPTOR_SCHEME = new ImmutableArray<>("http");
+    protected static final ImmutableArray<String> ADAPTOR_FILE_SCHEME = new ImmutableArray<>("http");
 
     /** The locations supported by this adaptor */
     private static final ImmutableArray<String> ADAPTOR_LOCATIONS = new ImmutableArray<>("[user@]host[:port]");
@@ -107,7 +107,7 @@ public class WebdavAdaptor extends Adaptor {
     private Credentials credentialsAdaptor;
 
     public WebdavAdaptor(XenonEngine xenonEngine, Map<String, String> properties) throws XenonException {
-        super(xenonEngine, ADAPTOR_NAME, ADAPTOR_DESCRIPTION, ADAPTOR_SCHEME, ADAPTOR_LOCATIONS, VALID_PROPERTIES,
+        super(xenonEngine, ADAPTOR_NAME, ADAPTOR_DESCRIPTION, null, ADAPTOR_FILE_SCHEME, ADAPTOR_LOCATIONS, VALID_PROPERTIES,
                 new XenonProperties(VALID_PROPERTIES, Component.XENON, properties));
 
         filesAdaptor = new WebdavFiles(this);

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/webdav/WebdavFiles.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/webdav/WebdavFiles.java
@@ -164,6 +164,11 @@ public class WebdavFiles implements Files {
         return fileSystem;
     }
 
+    @Override
+    public String [] getSupportedSchemes() throws XenonException { 
+        return adaptor.getSupportedFileSchemes();
+    }
+    
     private HttpClient getClient(WebdavLocation webdavLocation) {
         HostConfiguration hostConfig = new HostConfiguration();
         hostConfig.setHost(webdavLocation.getHost(), webdavLocation.getPort());

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/webdav/WebdavLocation.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/webdav/WebdavLocation.java
@@ -25,7 +25,7 @@ public class WebdavLocation extends Location {
     }
 
     protected WebdavLocation(String location) throws InvalidLocationException {
-        super(location, WebdavAdaptor.ADAPTOR_SCHEME.get(0));
+        super(location, WebdavAdaptor.ADAPTOR_FILE_SCHEME.get(0));
     }
 
     @Override

--- a/src/main/java/nl/esciencecenter/xenon/engine/AdaptorStatusImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/AdaptorStatusImplementation.java
@@ -20,29 +20,43 @@ import java.util.Map;
 import nl.esciencecenter.xenon.AdaptorStatus;
 import nl.esciencecenter.xenon.XenonPropertyDescription;
 import nl.esciencecenter.xenon.engine.util.ImmutableArray;
+import nl.esciencecenter.xenon.util.Utils;
 
 public class AdaptorStatusImplementation implements AdaptorStatus {
 
     private final String name;
     private final String description;
-    private final ImmutableArray<String> supportedSchemes;
+    private final ImmutableArray<String> supportedJobSchemes;
+    private final ImmutableArray<String> supportedFileSchemes;
+
     private final ImmutableArray<String> supportedLocations;
     private final ImmutableArray<XenonPropertyDescription> supportedProperties;
     private final Map<String, String> adaptorSpecificInformation;
 
-    public AdaptorStatusImplementation(String name, String description, ImmutableArray<String> supportedSchemes,
-            ImmutableArray<String> supportedLocations, ImmutableArray<XenonPropertyDescription> supportedProperties, 
-            Map<String, String> adaptorSpecificInformation) {
+    public AdaptorStatusImplementation(String name, String description, ImmutableArray<String> supportedJobSchemes,
+            ImmutableArray<String> supportedFileSchemes, ImmutableArray<String> supportedLocations, 
+            ImmutableArray<XenonPropertyDescription> supportedProperties, Map<String, String> adaptorSpecificInformation) {
 
         super();
         this.name = name;
         this.description = description;
         
-        if (supportedSchemes == null) { 
-            throw new IllegalArgumentException("Schemes is null!");
+        if (supportedJobSchemes == null && supportedFileSchemes == null) { 
+            throw new IllegalArgumentException("Both Job and File schemes are null!");
         }
         
-        this.supportedSchemes = supportedSchemes;
+        if (supportedJobSchemes == null) { 
+            this.supportedJobSchemes = new ImmutableArray<>();
+        } else { 
+            this.supportedJobSchemes = supportedJobSchemes;
+        }
+            
+        if (supportedFileSchemes == null) { 
+            this.supportedFileSchemes = new ImmutableArray<>();
+        } else { 
+            this.supportedFileSchemes = supportedFileSchemes;
+        }
+        
         this.supportedLocations = supportedLocations;
         
         if (supportedProperties == null) { 
@@ -64,8 +78,18 @@ public class AdaptorStatusImplementation implements AdaptorStatus {
     }
 
     @Override
+    public String[] getSupportedJobSchemes() {
+        return supportedJobSchemes.asArray();
+    }
+
+    @Override
+    public String[] getSupportedFileSchemes() {
+        return supportedFileSchemes.asArray();
+    }
+    
+    @Override
     public String[] getSupportedSchemes() {
-        return supportedSchemes.asArray();
+        return Utils.merge(getSupportedJobSchemes(), getSupportedFileSchemes());
     }
 
     @Override
@@ -85,8 +109,8 @@ public class AdaptorStatusImplementation implements AdaptorStatus {
 
     @Override
     public String toString() {
-        return "AdaptorStatusImplementation [name=" + name + ", description=" + description + ", supportedSchemes="
-                + supportedSchemes + ", supportedProperties=" + supportedProperties + ", adaptorSpecificInformation=" 
-                + adaptorSpecificInformation + "]";
+        return "AdaptorStatusImplementation [name=" + name + ", description=" + description + ", supportedJobSchemes="
+                + supportedJobSchemes + ", supportedFileSchemes=" + supportedFileSchemes +", supportedProperties=" 
+                + supportedProperties + ", adaptorSpecificInformation=" + adaptorSpecificInformation + "]";
     }
 }

--- a/src/main/java/nl/esciencecenter/xenon/engine/XenonEngine.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/XenonEngine.java
@@ -49,6 +49,7 @@ import nl.esciencecenter.xenon.engine.jobs.JobsEngine;
 import nl.esciencecenter.xenon.engine.util.CopyEngine;
 import nl.esciencecenter.xenon.files.Files;
 import nl.esciencecenter.xenon.jobs.Jobs;
+import nl.esciencecenter.xenon.util.Utils;
 
 /**
  * XenonEngine implements the Xenon Interface class by redirecting all calls to {@link Adaptor}s.
@@ -212,8 +213,30 @@ public final class XenonEngine implements Xenon {
         return tmp;
     }
 
-    // ************** Xenon Interface Implementation ***************\\
+    public String [] getSupportedJobsSchemes() { 
 
+        String [] tmp = null;
+        
+        for (int i = 0; i < adaptors.length; i++) {
+            tmp = Utils.merge(tmp, adaptors[i].getSupportedJobSchemes());
+        }
+
+        return tmp;
+    }
+
+    public String [] getSupportedFileSchemes() { 
+
+        String [] tmp = null;
+        
+        for (int i = 0; i < adaptors.length; i++) {
+            tmp = Utils.merge(tmp, adaptors[i].getSupportedFileSchemes());
+        }
+
+        return tmp;
+    }
+    
+    // ************** Xenon Interface Implementation ***************\\
+    
     @Override
     public AdaptorStatus[] getAdaptorStatuses() {
 

--- a/src/main/java/nl/esciencecenter/xenon/engine/files/FilesEngine.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/files/FilesEngine.java
@@ -98,6 +98,11 @@ public class FilesEngine implements Files {
     }
 
     @Override
+    public String [] getSupportedSchemes() throws XenonException { 
+        return xenonEngine.getSupportedFileSchemes();
+    }
+    
+    @Override
     public Path newPath(FileSystem filesystem, RelativePath location) throws XenonException {
         return getFilesAdaptor(filesystem).newPath(filesystem, location);
     }

--- a/src/main/java/nl/esciencecenter/xenon/engine/jobs/JobsEngine.java
+++ b/src/main/java/nl/esciencecenter/xenon/engine/jobs/JobsEngine.java
@@ -42,6 +42,7 @@ public class JobsEngine implements Jobs {
         return xenonEngine.getAdaptor(scheduler.getAdaptorName());
     }
 
+    @Override
     public Scheduler newScheduler(String scheme, String location, Credential credential, Map<String, String> properties) 
             throws XenonException {
 
@@ -49,6 +50,26 @@ public class JobsEngine implements Jobs {
         return adaptor.jobsAdaptor().newScheduler(scheme, location, credential, properties);
     }
 
+    @Override
+    public String [] getSupportedSchemes() { 
+        return xenonEngine.getSupportedJobsSchemes();
+    }
+    
+    @Override
+    public boolean isOnline(String scheme) throws XenonException { 
+        return xenonEngine.getAdaptorFor(scheme).jobsAdaptor().isOnline(scheme);
+    }
+    
+    @Override
+    public boolean supportsInteractive(String scheme) throws XenonException { 
+        return xenonEngine.getAdaptorFor(scheme).jobsAdaptor().supportsInteractive(scheme);
+    }
+
+    @Override
+    public  boolean supportsBatch(String scheme) throws XenonException { 
+        return xenonEngine.getAdaptorFor(scheme).jobsAdaptor().supportsBatch(scheme);    
+    }
+    
     @Override
     public void close(Scheduler scheduler) throws XenonException {
         getAdaptor(scheduler).jobsAdaptor().close(scheduler);

--- a/src/main/java/nl/esciencecenter/xenon/files/Files.java
+++ b/src/main/java/nl/esciencecenter/xenon/files/Files.java
@@ -76,6 +76,16 @@ public interface Files {
             throws XenonException;
         
     /**
+     * Get a list of file schemes supported by Xenon. 
+     * 
+     * @return the list of file schemes supported by Xenon.
+     * 
+     * @throws XenonException
+     *             If the list of file schemes could not be retrieved.
+     */
+    String [] getSupportedSchemes() throws XenonException;
+    
+    /**
      * Create a new Path that represents a (possibly non existing) location on <code>filesystem.</code>
      *  
      * @param filesystem

--- a/src/main/java/nl/esciencecenter/xenon/jobs/Jobs.java
+++ b/src/main/java/nl/esciencecenter/xenon/jobs/Jobs.java
@@ -70,6 +70,66 @@ public interface Jobs {
             throws XenonException;
     
     /**
+     * Get a list of job schemes supported by Xenon. 
+     * 
+     * @return the list of job schemes supported by Xenon.
+     * 
+     * @throws XenonException
+     *             If the list of schemes could not be retrieved.
+     */
+    String [] getSupportedSchemes() throws XenonException;
+    
+    /**
+     * Does this scheme require an online scheduler ?
+     * 
+     * Online schedulers need to remain active for their jobs to run. Ending an online scheduler will kill all jobs that were
+     * submitted to it.
+     * 
+     * Offline schedulers do not need to remains active for their jobs to run. A submitted job will typically be handed over to
+     * some external server that will manage the job for the rest of its lifetime.
+     * 
+     * Online schedulers typically support both interactive jobs (where the user controls the standard streams) and batch jobs
+     * (where the standard streams are redirected to/from files).
+     * 
+     * Since it is impossible to continue an interactive jobs when a scheduler ends, interactive jobs will always be killed,
+     * even in an offline scheduler.
+     * 
+     * @return if this scheme requires an online scheduler.
+     * 
+     * @throws XenonException
+     *             If information on the scheme could not be retrieved.
+     */
+    boolean isOnline(String scheme) throws XenonException;
+    
+    /**
+     * Does this scheme supports the submission of interactive jobs ?
+     * 
+     * For interactive jobs the standard streams of the job must be handled by the submitting process. Failing to do so may cause
+     * the job to hang indefinitely.
+     * 
+     * Note that it is impossible to continue an interactive jobs when its scheduler ends. This will cause the interactive job
+     * to be killed,
+     * 
+     * @return if this scheme supports the submission of interactive jobs ?
+     * 
+     * @throws XenonException
+     *             If information on the scheme could not be retrieved.
+     */
+    boolean supportsInteractive(String scheme) throws XenonException;
+
+    /**
+     * Does this scheme support the submission of batch jobs ?
+     * 
+     * For batch jobs the standard streams of the jobs are redirected from / to files.
+     * 
+     * @return if this scheme supports the submission of batch jobs ?
+     * 
+     * @throws XenonException
+     *             If information on the scheme could not be retrieved.
+     */
+    boolean supportsBatch(String scheme) throws XenonException;
+    
+    /**
      * Close a Scheduler.
      * 
      * @param scheduler

--- a/src/main/java/nl/esciencecenter/xenon/util/Utils.java
+++ b/src/main/java/nl/esciencecenter/xenon/util/Utils.java
@@ -28,6 +28,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -1263,4 +1264,43 @@ public final class Utils {
     
         return b.toString();
     }   
+    
+    /**
+     * Merge two String arrays into a single one. 
+     * 
+     * If one of the arrays is <code>null</code>, a copy of the other will be returned. If both arrays are <code>null</code> an 
+     * empty String [] will be returned. If both arrays are not <code>null</code>, a new array will be returned containing the 
+     * content of a1 and a2 (in that order). 
+     * 
+     * Note that any <code>null</code> value in the arrays will be copied as is.      
+     * 
+     * @param a1
+     *          Array to merge   
+     * @param a2
+     *          Array to merge   
+     * 
+     * @return
+     *          A new array containing the values contained in a1 and a2, in that order.
+     */
+    public static String[] merge(String [] a1, String[] a2) {
+    
+        if (a1 == null && a2 == null) { 
+            return new String[0];
+        }
+        
+        if (a1 == null) { 
+            return a2.clone();
+        }
+        
+        if (a2 == null) { 
+            return a1.clone();
+        }
+        
+        String [] tmp = Arrays.copyOf(a1, a1.length + a2.length);
+        
+        System.arraycopy(a2, 0, tmp, a1.length, a2.length);
+        
+        return tmp;
+    }
+    
 }

--- a/src/test/java/nl/esciencecenter/xenon/engine/AdaptorStatusImplementationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/AdaptorStatusImplementationTest.java
@@ -77,7 +77,7 @@ public class AdaptorStatusImplementationTest {
                 new ImmutableArray<>("L1", "L2"), new ImmutableArray<XenonPropertyDescription>(), null).toString();
 
         assert (tmp.equals("AdaptorStatusImplementation [name=NAME, description=DESCRIPTION, supportedJobSchemes=[SCHEME1, " +
-        		"SCHEME2], supportedJobSchemes=[] supportedProperties=[], adaptorSpecificInformation=null]"));
+        		"SCHEME2], supportedFileSchemes=[] supportedProperties=[], adaptorSpecificInformation=null]"));
     }
 
 }

--- a/src/test/java/nl/esciencecenter/xenon/engine/AdaptorStatusImplementationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/AdaptorStatusImplementationTest.java
@@ -31,10 +31,10 @@ import org.junit.Test;
 public class AdaptorStatusImplementationTest {
 
     @Test
-    public void testGetters() {
+    public void testGetters1() {
 
         AdaptorStatusImplementation a = new AdaptorStatusImplementation("NAME", "DESCRIPTION", 
-                new ImmutableArray<>("SCHEME1", "SCHEME2"),new ImmutableArray<>("L1", "L2"), 
+                new ImmutableArray<>("SCHEME1"), new ImmutableArray<>("SCHEME2"), new ImmutableArray<>("L1", "L2"), 
                 new ImmutableArray<XenonPropertyDescription>(), null);
 
         assertEquals("NAME", a.getName());
@@ -46,6 +46,18 @@ public class AdaptorStatusImplementationTest {
         assertEquals(2, schemes.length);
         assertEquals("SCHEME1", schemes[0]);
         assertEquals("SCHEME2", schemes[1]);
+
+        String[] jobschemes = a.getSupportedJobSchemes();
+
+        assertNotNull(jobschemes);
+        assertEquals(1, jobschemes.length);
+        assertEquals("SCHEME1", jobschemes[0]);
+
+        String[] fileschemes = a.getSupportedFileSchemes();
+
+        assertNotNull(fileschemes);
+        assertEquals(1, fileschemes.length);
+        assertEquals("SCHEME2", fileschemes[0]);
 
         String[] locations = a.getSupportedLocations();
 
@@ -61,11 +73,11 @@ public class AdaptorStatusImplementationTest {
     @Test
     public void testToString() {
 
-        String tmp = new AdaptorStatusImplementation("NAME", "DESCRIPTION", new ImmutableArray<>("SCHEME1", "SCHEME2"),
+        String tmp = new AdaptorStatusImplementation("NAME", "DESCRIPTION", new ImmutableArray<>("SCHEME1", "SCHEME2"), null,
                 new ImmutableArray<>("L1", "L2"), new ImmutableArray<XenonPropertyDescription>(), null).toString();
 
-        assert (tmp.equals("AdaptorStatusImplementation [name=NAME, description=DESCRIPTION, supportedSchemes=[SCHEME1, " +
-        		"SCHEME2], supportedProperties=[], adaptorSpecificInformation=null]"));
+        assert (tmp.equals("AdaptorStatusImplementation [name=NAME, description=DESCRIPTION, supportedJobSchemes=[SCHEME1, " +
+        		"SCHEME2], supportedJobSchemes=[] supportedProperties=[], adaptorSpecificInformation=null]"));
     }
 
 }

--- a/src/test/java/nl/esciencecenter/xenon/engine/AdaptorStatusImplementationTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/AdaptorStatusImplementationTest.java
@@ -75,9 +75,9 @@ public class AdaptorStatusImplementationTest {
 
         String tmp = new AdaptorStatusImplementation("NAME", "DESCRIPTION", new ImmutableArray<>("SCHEME1", "SCHEME2"), null,
                 new ImmutableArray<>("L1", "L2"), new ImmutableArray<XenonPropertyDescription>(), null).toString();
-
+        
         assert (tmp.equals("AdaptorStatusImplementation [name=NAME, description=DESCRIPTION, supportedJobSchemes=[SCHEME1, " +
-        		"SCHEME2], supportedFileSchemes=[] supportedProperties=[], adaptorSpecificInformation=null]"));
+        		"SCHEME2], supportedFileSchemes=[], supportedProperties=[], adaptorSpecificInformation=null]"));
     }
 
 }

--- a/src/test/java/nl/esciencecenter/xenon/engine/AdaptorTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/AdaptorTest.java
@@ -31,7 +31,6 @@ import nl.esciencecenter.xenon.credentials.Credentials;
 import nl.esciencecenter.xenon.engine.util.ImmutableArray;
 import nl.esciencecenter.xenon.files.Files;
 import nl.esciencecenter.xenon.jobs.Jobs;
-import nl.esciencecenter.xenon.util.Utils;
 
 import org.junit.Test;
 
@@ -72,15 +71,6 @@ public class AdaptorTest {
 
         @Override
         public void end() { /* noop */ }
-
-        /**
-         * @return
-         */
-        public String[] getSupportedJobSchemes() {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
     }
 
     @Test
@@ -167,7 +157,7 @@ public class AdaptorTest {
         TestAdaptor t = new TestAdaptor(null, "test", "DESCRIPTION", null, schemesFile, locations, 
                 new ImmutableArray<XenonPropertyDescription>(), new XenonProperties());
 
-        String[] tmp = t.getSupportedFileSchemes();
+        String[] tmp = t.getSupportedJobSchemes();
         
         assert (tmp != null);
         assert (Arrays.equals(new String[0], tmp));
@@ -228,7 +218,7 @@ public class AdaptorTest {
 
         ImmutableArray<String> locations = new ImmutableArray<>("L1", "L2");
 
-        TestAdaptor t = new TestAdaptor(null, "test", "DESCRIPTION", null, null, locations, 
+        new TestAdaptor(null, "test", "DESCRIPTION", null, null, locations,
                 new ImmutableArray<XenonPropertyDescription>(), new XenonProperties());
     }
     

--- a/src/test/java/nl/esciencecenter/xenon/engine/AdaptorTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/engine/AdaptorTest.java
@@ -31,6 +31,7 @@ import nl.esciencecenter.xenon.credentials.Credentials;
 import nl.esciencecenter.xenon.engine.util.ImmutableArray;
 import nl.esciencecenter.xenon.files.Files;
 import nl.esciencecenter.xenon.jobs.Jobs;
+import nl.esciencecenter.xenon.util.Utils;
 
 import org.junit.Test;
 
@@ -41,11 +42,12 @@ public class AdaptorTest {
 
     class TestAdaptor extends Adaptor {
 
-        public TestAdaptor(XenonEngine xenonEngine, String name, String description, ImmutableArray<String> supportedSchemes,
-                ImmutableArray<String> supportedLocations, ImmutableArray<XenonPropertyDescription> validProperties, 
-                XenonProperties p) throws XenonException {
+        public TestAdaptor(XenonEngine xenonEngine, String name, String description, ImmutableArray<String> supportedJobSchemes,
+                ImmutableArray<String> supportedFileSchemes, ImmutableArray<String> supportedLocations, 
+                ImmutableArray<XenonPropertyDescription> validProperties, XenonProperties p) throws XenonException {
 
-            super(xenonEngine, name, description, supportedSchemes, supportedLocations, validProperties, p);
+            super(xenonEngine, name, description, supportedJobSchemes, supportedFileSchemes, supportedLocations, validProperties,
+                    p);
         }
 
         @Override
@@ -71,25 +73,167 @@ public class AdaptorTest {
         @Override
         public void end() { /* noop */ }
 
+        /**
+         * @return
+         */
+        public String[] getSupportedJobSchemes() {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
     }
 
     @Test
-    public void test0() throws XenonException {
+    public void testJobScheme1() throws XenonException {
 
-        ImmutableArray<String> schemes = new ImmutableArray<>("SCHEME1", "SCHEME2");
+        ImmutableArray<String> schemesJob = new ImmutableArray<>("SCHEME1", "SCHEME2");
         ImmutableArray<String> locations = new ImmutableArray<>("L1", "L2");
 
-        TestAdaptor t = new TestAdaptor(null, "test", "DESCRIPTION", schemes, locations, 
+        TestAdaptor t = new TestAdaptor(null, "test", "DESCRIPTION", schemesJob, null, locations, 
                 new ImmutableArray<XenonPropertyDescription>(), new XenonProperties());
 
         String[] tmp = t.getSupportedSchemes();
-
+        
         assert (tmp != null);
-        assert (Arrays.equals(schemes.asArray(), tmp));
+        assert (Arrays.equals(schemesJob.asArray(), tmp));
     }
 
     @Test
-    public void test1() throws XenonException {
+    public void testJobScheme2() throws XenonException {
+
+        ImmutableArray<String> schemesJob = new ImmutableArray<>("SCHEME1", "SCHEME2");
+        ImmutableArray<String> locations = new ImmutableArray<>("L1", "L2");
+
+        TestAdaptor t = new TestAdaptor(null, "test", "DESCRIPTION", schemesJob, null, locations, 
+                new ImmutableArray<XenonPropertyDescription>(), new XenonProperties());
+
+        String[] tmp = t.getSupportedJobSchemes();
+        
+        assert (tmp != null);
+        assert (Arrays.equals(schemesJob.asArray(), tmp));
+    }
+
+    @Test
+    public void testJobScheme3() throws XenonException {
+
+        ImmutableArray<String> schemesJob = new ImmutableArray<>("SCHEME1", "SCHEME2");
+        ImmutableArray<String> locations = new ImmutableArray<>("L1", "L2");
+
+        TestAdaptor t = new TestAdaptor(null, "test", "DESCRIPTION", schemesJob, null, locations, 
+                new ImmutableArray<XenonPropertyDescription>(), new XenonProperties());
+
+        String[] tmp = t.getSupportedFileSchemes();
+        
+        assert (tmp != null);
+        assert (Arrays.equals(new String[0], tmp));
+    }
+
+    @Test
+    public void testFileScheme1() throws XenonException {
+
+        ImmutableArray<String> schemesFile = new ImmutableArray<>("SCHEME1", "SCHEME2");
+        ImmutableArray<String> locations = new ImmutableArray<>("L1", "L2");
+
+        TestAdaptor t = new TestAdaptor(null, "test", "DESCRIPTION", null, schemesFile, locations, 
+                new ImmutableArray<XenonPropertyDescription>(), new XenonProperties());
+
+        String[] tmp = t.getSupportedSchemes();
+        
+        assert (tmp != null);
+        assert (Arrays.equals(schemesFile.asArray(), tmp));
+    }
+
+    @Test
+    public void testFileScheme2() throws XenonException {
+
+        ImmutableArray<String> schemesFile = new ImmutableArray<>("SCHEME1", "SCHEME2");
+        ImmutableArray<String> locations = new ImmutableArray<>("L1", "L2");
+
+        TestAdaptor t = new TestAdaptor(null, "test", "DESCRIPTION", null, schemesFile,locations, 
+                new ImmutableArray<XenonPropertyDescription>(), new XenonProperties());
+
+        String[] tmp = t.getSupportedFileSchemes();
+        
+        assert (tmp != null);
+        assert (Arrays.equals(schemesFile.asArray(), tmp));
+    }
+
+    @Test
+    public void testFileScheme3() throws XenonException {
+
+        ImmutableArray<String> schemesFile = new ImmutableArray<>("SCHEME1", "SCHEME2");
+        ImmutableArray<String> locations = new ImmutableArray<>("L1", "L2");
+
+        TestAdaptor t = new TestAdaptor(null, "test", "DESCRIPTION", null, schemesFile, locations, 
+                new ImmutableArray<XenonPropertyDescription>(), new XenonProperties());
+
+        String[] tmp = t.getSupportedFileSchemes();
+        
+        assert (tmp != null);
+        assert (Arrays.equals(new String[0], tmp));
+    }
+
+    @Test
+    public void testJobAndFileScheme1() throws XenonException {
+
+        ImmutableArray<String> schemesJob = new ImmutableArray<>("SCHEME1");
+        ImmutableArray<String> schemesFile = new ImmutableArray<>("SCHEME2");
+        ImmutableArray<String> locations = new ImmutableArray<>("L1", "L2");
+
+        TestAdaptor t = new TestAdaptor(null, "test", "DESCRIPTION", schemesJob, schemesFile, locations, 
+                new ImmutableArray<XenonPropertyDescription>(), new XenonProperties());
+
+        String[] tmp = t.getSupportedSchemes();
+        String[] result = new String[] { "SCHEME1", "SCHEME2" };         
+        assert (tmp != null);
+        assert (Arrays.equals(result, tmp));
+    }
+
+    
+    @Test
+    public void testJobAndFileScheme2() throws XenonException {
+
+        ImmutableArray<String> schemesJob = new ImmutableArray<>("SCHEME1");
+        ImmutableArray<String> schemesFile = new ImmutableArray<>("SCHEME2");
+        ImmutableArray<String> locations = new ImmutableArray<>("L1", "L2");
+
+        TestAdaptor t = new TestAdaptor(null, "test", "DESCRIPTION", schemesJob, schemesFile, locations, 
+                new ImmutableArray<XenonPropertyDescription>(), new XenonProperties());
+
+        String[] tmp = t.getSupportedJobSchemes();
+         
+        assert (tmp != null);
+        assert (Arrays.equals(schemesJob.asArray(), tmp));
+    }
+
+    
+    @Test
+    public void testJobAndFileScheme3() throws XenonException {
+
+        ImmutableArray<String> schemesJob = new ImmutableArray<>("SCHEME1");
+        ImmutableArray<String> schemesFile = new ImmutableArray<>("SCHEME2");
+        ImmutableArray<String> locations = new ImmutableArray<>("L1", "L2");
+
+        TestAdaptor t = new TestAdaptor(null, "test", "DESCRIPTION", schemesJob, schemesFile, locations, 
+                new ImmutableArray<XenonPropertyDescription>(), new XenonProperties());
+
+        String[] tmp = t.getSupportedFileSchemes();
+         
+        assert (tmp != null);
+        assert (Arrays.equals(schemesFile.asArray(), tmp));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testJobAndFileSchemeNull() throws XenonException {
+
+        ImmutableArray<String> locations = new ImmutableArray<>("L1", "L2");
+
+        TestAdaptor t = new TestAdaptor(null, "test", "DESCRIPTION", null, null, locations, 
+                new ImmutableArray<XenonPropertyDescription>(), new XenonProperties());
+    }
+    
+    @Test
+    public void testSupportedProperties1() throws XenonException {
 
         ImmutableArray<String> schemes = new ImmutableArray<>("SCHEME1", "SCHEME2");
         ImmutableArray<String> locations = new ImmutableArray<>("L1", "L2");
@@ -102,7 +246,7 @@ public class AdaptorTest {
                         "noot2", "test property p2"));
 
         XenonProperties prop = new XenonProperties(supportedProperties, new HashMap<String, String>(0));
-        TestAdaptor t = new TestAdaptor(null, "test", "DESCRIPTION", schemes, locations, supportedProperties, prop);
+        TestAdaptor t = new TestAdaptor(null, "test", "DESCRIPTION", schemes, null, locations, supportedProperties, prop);
 
         XenonPropertyDescription[] p = t.getSupportedProperties();
 
@@ -118,7 +262,7 @@ public class AdaptorTest {
     }
 
     @Test
-    public void test2() throws XenonException {
+    public void testSupportedProperties2() throws XenonException {
         ImmutableArray<String> schemes = new ImmutableArray<>("SCHEME1", "SCHEME2");
         ImmutableArray<String> locations = new ImmutableArray<>("L1", "L2");
 
@@ -133,7 +277,7 @@ public class AdaptorTest {
         m.put("xenon.adaptors.test.p2", "zus");
 
         XenonProperties prop = new XenonProperties(supportedProperties, m);
-        TestAdaptor t = new TestAdaptor(null, "test", "DESCRIPTION", schemes, locations, supportedProperties, prop);
+        TestAdaptor t = new TestAdaptor(null, "test", "DESCRIPTION", schemes, null, locations, supportedProperties, prop);
 
         XenonPropertyDescription[] p = t.getSupportedProperties();
 
@@ -150,7 +294,7 @@ public class AdaptorTest {
 }
 
     @Test(expected = XenonException.class)
-    public void test3() throws XenonException {
+    public void testSupportedPropertiesFails() throws XenonException {
 
         ImmutableArray<String> schemes = new ImmutableArray<>("SCHEME1", "SCHEME2");
         ImmutableArray<String> locations = new ImmutableArray<>("L1", "L2");
@@ -167,7 +311,7 @@ public class AdaptorTest {
 
         XenonProperties prop = new XenonProperties(supportedProperties, p);
 
-        new TestAdaptor(null, "test", "DESCRIPTION", schemes, locations, supportedProperties, prop);
+        new TestAdaptor(null, "test", "DESCRIPTION", schemes, null, locations, supportedProperties, prop);
     }
 
 }


### PR DESCRIPTION
Extended API with support for separately requesting the Job and File schemes. This allows easier inspection in the application of what you can do with Xenon. 

In addition, you can now use the scheme and the Jobs API to determine if a scheduler is online, and if it supports interactive and batch jobs. Previously, this could only be checked after the scheduler was created. 