### PR TITLE
Enable Jitpack

### DIFF
--- a/gradle/documentation.gradle
+++ b/gradle/documentation.gradle
@@ -1,8 +1,9 @@
 // javadoc and userguide generation
 
 javadoc {
-    exclude 'nl/esciencecenter/xenon/engine/**', 'nl/esciencecenter/xenon/adaptors/**'
+    exclude 'nl/esciencecenter/xenon/adaptors/**'
     options.overview = file("${buildDir}/overview.html")
+    options.showFromPublic()
     options.setNoTimestamp(true)
 }
 
@@ -15,8 +16,8 @@ task javadocDevel(type: Javadoc) {
     destinationDir = file("${project.docsDir}/javadoc-devel")
     options.showFromPrivate()
     options.overview = file("${buildDir}/overview.html")
+    options.setNoTimestamp(true)
 }
-
 
 task adaptorDocumentation(type: JavaExec) {
     description 'Generates html snippet with options of adaptors (used in the javadoc overview page)'

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+install:
+- /gradlew clean -Pgroup=com.github.NLeSC -xtest -xintegrationTest build publishToMavenLocal

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 install:
-- ./gradlew clean -Pgroup=$GROUP -P -Pversion=$VERSION -xtest -xintegrationTest build publishToMavenLocal
+- ./gradlew clean -Pgroup=$GROUP -Pversion=$VERSION -xtest -xintegrationTest build publishToMavenLocal

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 install:
-- /gradlew clean -Pgroup=com.github.NLeSC -xtest -xintegrationTest build publishToMavenLocal
+- ./gradlew clean -Pgroup=$GROUP -P -Pversion=$VERSION -xtest -xintegrationTest build publishToMavenLocal

--- a/src/main/java/nl/esciencecenter/xenon/utils/AdaptorDocGenerator.java
+++ b/src/main/java/nl/esciencecenter/xenon/utils/AdaptorDocGenerator.java
@@ -67,6 +67,10 @@ public class AdaptorDocGenerator {
     public void generate(PrintWriter out) throws XenonException {
         out.println("<!DOCTYPE html><html><head><meta charset=\"UTF-8\"><title>Xenon Javadoc overview</title></head><body>");
         out.println("A middleware abstraction library that provides a simple programming interface to various compute and storage resources.");
+        out.println("<p>The main entry points are<ul>");
+        out.println("<li><a href=\"nl/esciencecenter/xenon/schedulers/Scheduler.html\">nl.esciencecenter.xenon.schedulers.Scheduler</a></li>");
+        out.println("<li><a href=\"nl/esciencecenter/xenon/filesystems/FileSystem.html\">nl.esciencecenter.xenon.filesystems.FileSystem</a></li>");
+        out.println("</ul></p>");
         out.println("<h1>Adaptor Documentation</h1>");
         out.println("<p>This section contains the adaptor documentation which is generated "
                 + "from the information provided by the adaptors themselves.</p>");


### PR DESCRIPTION
By adding to build.gradle of repo that depends on Xenon use
```
repositories {
   maven { url 'https://jitpack.io' }
}
dependencies {
    compile 'com.github.NLeSC:Xenon:jitpack-SNAPSHOT'
}
```

As bonus javadoc is available at https://jitpack.io/com/github/NLeSC/Xenon/jitpack-SNAPSHOT/javadoc/index.html