### PR TITLE
Exceptions and documentation

### DIFF
--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/filesystems/FileSystemTestParent.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/filesystems/FileSystemTestParent.java
@@ -16,21 +16,47 @@
 package nl.esciencecenter.xenon.adaptors.filesystems;
 
 
-import static org.junit.Assert.*;
+import nl.esciencecenter.xenon.XenonException;
+import nl.esciencecenter.xenon.adaptors.NotConnectedException;
+import nl.esciencecenter.xenon.filesystems.CopyMode;
+import nl.esciencecenter.xenon.filesystems.CopyStatus;
+import nl.esciencecenter.xenon.filesystems.DirectoryNotEmptyException;
+import nl.esciencecenter.xenon.filesystems.FileSystem;
+import nl.esciencecenter.xenon.filesystems.FileSystemAdaptorDescription;
+import nl.esciencecenter.xenon.filesystems.InvalidPathException;
+import nl.esciencecenter.xenon.filesystems.NoSuchCopyException;
+import nl.esciencecenter.xenon.filesystems.NoSuchPathException;
+import nl.esciencecenter.xenon.filesystems.Path;
+import nl.esciencecenter.xenon.filesystems.PathAlreadyExistsException;
+import nl.esciencecenter.xenon.filesystems.PathAttributes;
+import nl.esciencecenter.xenon.filesystems.PosixFilePermission;
+import nl.esciencecenter.xenon.utils.OutputReader;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
-
-import java.io.*;
-import java.util.*;
-
-import nl.esciencecenter.xenon.adaptors.NotConnectedException;
-import nl.esciencecenter.xenon.filesystems.*;
-import org.junit.*;
-import org.junit.rules.ExpectedException;
-
-import nl.esciencecenter.xenon.XenonException;
-import nl.esciencecenter.xenon.utils.OutputReader;
-import org.junit.rules.Timeout;
 
 public abstract class FileSystemTestParent {
 
@@ -71,8 +97,10 @@ public abstract class FileSystemTestParent {
 
         //System.out.println("TEST_ROOT=" + testRoot);
 
+        if (fileSystem.exists(testRoot)) {
+            fileSystem.delete(testRoot, true);
+        }
         fileSystem.createDirectory(testRoot);
-
 
         testDir = null;
     }
@@ -1158,8 +1186,8 @@ public abstract class FileSystemTestParent {
     public void test_readFromFile_closed_throwsException() throws Exception {
         assumeFalse(description.isConnectionless());
         fileSystem.close();
-        fileSystem.readFromFile(testDir);
 
+        fileSystem.readFromFile(locationConfig.getExistingPath());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/filesystems/FileSystemTestParent.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/filesystems/FileSystemTestParent.java
@@ -37,26 +37,24 @@ import nl.esciencecenter.xenon.utils.OutputReader;
 import org.junit.rules.Timeout;
 
 public abstract class FileSystemTestParent {
-	
-	public static final String TEST_DIR = "xenon_test";
-    
+
+    public static final String TEST_DIR = "xenon_test";
+
     private Path testRoot;
-    
+
     private FileSystem fileSystem;
     private FileSystemAdaptorDescription description;
     private LocationConfig locationConfig;
     private Path testDir;
 
     private static long counter = 0;
-    
-    private static long getNextCounter() { 
-    	return counter++;
-    }
 
+    private static long getNextCounter() { 
+        return counter++;
+    }
 
     @Rule
     public Timeout globalTimeout = Timeout.seconds(10); // 10 seconds max per method tested
-
 
     @Rule
     public final ExpectedException exception = ExpectedException.none();
@@ -66,20 +64,20 @@ public abstract class FileSystemTestParent {
         fileSystem = setupFileSystem();
         description = setupDescription();
         locationConfig = setupLocationConfig(fileSystem);
-        
+
         Path root = locationConfig.getWritableTestDir();
-        
+
         //System.out.println("ROOT=" + root);
-        
+
         assertNotNull(root);
-        
+
         testRoot = root.resolve(TEST_DIR);
-        
+
         //System.out.println("TEST_ROOT=" + testRoot);
 
         fileSystem.createDirectory(testRoot);
 
-        
+
         testDir = null;
     }
 
@@ -88,10 +86,10 @@ public abstract class FileSystemTestParent {
     @After
     public void cleanup() throws XenonException {
         try {
-        	if (!fileSystem.isOpen()) { 
-        		return;
-        	}
-        	
+            if (!fileSystem.isOpen()) { 
+                return;
+            }
+
             if (testRoot != null && fileSystem.exists(testRoot)) {
                 fileSystem.delete(testRoot, true);
             }
@@ -119,8 +117,8 @@ public abstract class FileSystemTestParent {
 
     @Test
     public void readSymbolicLink_linkToExistingFile_targetMatches() throws XenonException {
-    	assumeTrue("Does not support reading of symlinks", description.canReadSymboliclinks());
-    	Map.Entry<Path, Path> linkTarget = locationConfig.getSymbolicLinksToExistingFile();
+        assumeTrue("Does not support reading of symlinks", description.canReadSymboliclinks());
+        Map.Entry<Path, Path> linkTarget = locationConfig.getSymbolicLinksToExistingFile();
         Path target = fileSystem.readSymbolicLink(linkTarget.getKey());
         Path expectedTarget = linkTarget.getValue();
         assertEquals(target, expectedTarget);
@@ -142,31 +140,31 @@ public abstract class FileSystemTestParent {
     }
 
     private String generateTestDirName() throws XenonException {
-    	return "dir" + getNextCounter();
+        return "dir" + getNextCounter();
     }
 
     private String generateTestFileName() throws XenonException {
-    	return "file" + getNextCounter();
+        return "file" + getNextCounter();
     }
 
     // Depends on: Path.resolve, RelativePath, exists
-//    private Path createNewTestDirName(Path root) throws XenonException {
-//        Path dir = resolve("dir" + getNextCounter());
-//        
-//        assertFalse("Generated test dir already exists! " + dir, fileSystem.exists(dir));
-//
-//        return dir;
-//    }
+    //    private Path createNewTestDirName(Path root) throws XenonException {
+    //        Path dir = resolve("dir" + getNextCounter());
+    //        
+    //        assertFalse("Generated test dir already exists! " + dir, fileSystem.exists(dir));
+    //
+    //        return dir;
+    //    }
 
     // Depends on: [createNewTestDirName], createDirectory, exists
-//    private Path createTestDir(Path root) throws Exception {
-//        Path dir = createNewTestDirName(root);
-//        fileSystem.createDirectory(dir);
-//
-//        assertTrue("Failed to generate test dir! " + dir, fileSystem.exists(dir));
-//
-//        return dir;
-//    }
+    //    private Path createTestDir(Path root) throws Exception {
+    //        Path dir = createNewTestDirName(root);
+    //        fileSystem.createDirectory(dir);
+    //
+    //        assertTrue("Failed to generate test dir! " + dir, fileSystem.exists(dir));
+    //
+    //        return dir;
+    //    }
 
     // Depends on: [createTestDir]
     protected void prepareTestDir(String testName) throws XenonException {
@@ -179,7 +177,7 @@ public abstract class FileSystemTestParent {
     // Depends on: Path.resolve, exists
     private Path createNewTestFileName(Path root) throws Exception {
         Path file = root.resolve( "file" + getNextCounter());
-        
+
         assertFalse("Generated NEW test file already exists! " + file, fileSystem.exists(file));
 
         return file;
@@ -191,7 +189,7 @@ public abstract class FileSystemTestParent {
         OutputStream out = null;
 
         try {
-        	out = fileSystem.writeToFile(testFile, data.length);
+            out = fileSystem.writeToFile(testFile, data.length);
 
             if (data != null) {
                 out.write(data);
@@ -208,6 +206,8 @@ public abstract class FileSystemTestParent {
     // Depends on: [createNewTestFileName], createFile, [writeData]
     protected Path createTestFile(Path root, byte[] data) throws Exception {
         Path file = createNewTestFileName(root);
+        
+        System.out.println("CREATE TEST FILE: " + file);
 
         fileSystem.createFile(file);
 
@@ -217,15 +217,15 @@ public abstract class FileSystemTestParent {
         return file;
     }
 
-//    // Depends on: exists, isDirectory, delete
-//    private void deleteTestFile(Path file) throws Exception {
-//        assertTrue("Cannot delete non-existing file: " + file, fileSystem.exists(file));
-//
-//        PathAttributes att = fileSystem.getAttributes(file);
-//        assertFalse("Cannot delete directory: " + file, att.isDirectory());
-//
-//        fileSystem.delete(file,false);
-//    }
+    //    // Depends on: exists, isDirectory, delete
+    //    private void deleteTestFile(Path file) throws Exception {
+    //        assertTrue("Cannot delete non-existing file: " + file, fileSystem.exists(file));
+    //
+    //        PathAttributes att = fileSystem.getAttributes(file);
+    //        assertFalse("Cannot delete directory: " + file, att.isDirectory());
+    //
+    //        fileSystem.delete(file,false);
+    //    }
 
     // Depends on: exists, isDirectory, delete
     protected void deleteTestDir(Path dir) throws Exception {
@@ -238,12 +238,12 @@ public abstract class FileSystemTestParent {
     }
 
     private void generateTestDir() throws XenonException { 
-    	testDir = resolve(generateTestDirName());    	
+        testDir = resolve(generateTestDirName());    	
     }
-    
+
     private void generateAndCreateTestDir() throws XenonException { 
-    	generateTestDir();
-    	fileSystem.createDirectories(testDir);    	
+        generateTestDir();
+        fileSystem.createDirectories(testDir);    	
     }
 
     private Path createTestSubDir(Path testDir) throws XenonException {
@@ -258,80 +258,80 @@ public abstract class FileSystemTestParent {
 
 
     // Tests to create directories
-    
+
     @Test
     public void test_exists_ok() throws Exception {
-    	assertTrue(fileSystem.exists(locationConfig.getExistingPath()));
+        assertTrue(fileSystem.exists(locationConfig.getExistingPath()));
     }
-  
+
     @Test
     public void test_exists_notExistsDir() throws Exception {
-    	assertFalse(fileSystem.exists(new Path("/foobar")));
+        assertFalse(fileSystem.exists(new Path("/foobar")));
     }
-      
+
     @Test(expected=IllegalArgumentException.class)
     public void test_createDirectory_null_throw() throws Exception {
-    	fileSystem.createDirectory(null);
+        fileSystem.createDirectory(null);
     }
-    
+
     @Test
     public void test_createDirectory_nonExisting_noThrow() throws Exception {
-    	generateAndCreateTestDir();
-    	assertTrue(fileSystem.exists(testDir));
-    	
+        generateAndCreateTestDir();
+        assertTrue(fileSystem.exists(testDir));
+
     }
 
     @Test(expected=PathAlreadyExistsException.class)
     public void createDirectory_existing_throw() throws Exception {
-    	generateAndCreateTestDir();
+        generateAndCreateTestDir();
         fileSystem.createDirectory(testDir);
     }
 
     @Test(expected=PathAlreadyExistsException.class)
     public void test_createDirectory_existingFile_throw() throws Exception {
-    	generateAndCreateTestDir();
+        generateAndCreateTestDir();
 
-    	String file = generateTestFileName();
-        
+        String file = generateTestFileName();
+
         Path tmp = testDir.resolve(file);
         fileSystem.createFile(tmp);
-        
+
         // Should fail!
         fileSystem.createDirectory(tmp);
     }
 
     @Test(expected=NoSuchPathException.class)
     public void test_createDirectory_nonExistingParent_throw() throws Exception {
-    	generateAndCreateTestDir();
-    	fileSystem.createDirectory(testDir.resolve(new Path("aap", "noot")));
+        generateAndCreateTestDir();
+        fileSystem.createDirectory(testDir.resolve(new Path("aap", "noot")));
     }
-    
-//    @Test(expected=XenonException.class)
-//    public void createDirectory_closedFileSystemIfSupported_throw() throws Exception {
-//        assumeFalse(description.isConnectionless());
-//        fileSystem.close();
-//        generateAndCreateTestDir();
-//    }
+
+    //    @Test(expected=XenonException.class)
+    //    public void createDirectory_closedFileSystemIfSupported_throw() throws Exception {
+    //        assumeFalse(description.isConnectionless());
+    //        fileSystem.close();
+    //        generateAndCreateTestDir();
+    //    }
 
 
     @Test(expected=IllegalArgumentException.class)
     public void test_createFile_null_throwsException() throws Exception {
-    	fileSystem.createFile(null);
+        fileSystem.createFile(null);
     }
 
     @Test
     public void test_createFile_nonExistingFile() throws Exception {
-    	generateAndCreateTestDir();
-    	Path file = testDir.resolve(generateTestFileName());    	
-    	fileSystem.createFile(file);
+        generateAndCreateTestDir();
+        Path file = testDir.resolve(generateTestFileName());    	
+        fileSystem.createFile(file);
     }
 
     @Test(expected=PathAlreadyExistsException.class)
     public void test_createFile_existingFile_throwsException() throws Exception {
-    	generateAndCreateTestDir();
-    	Path file = testDir.resolve(generateTestFileName());    	
-    	fileSystem.createFile(file);
-    	fileSystem.createFile(file);
+        generateAndCreateTestDir();
+        Path file = testDir.resolve(generateTestFileName());    	
+        fileSystem.createFile(file);
+        fileSystem.createFile(file);
     }
 
     @Test(expected=PathAlreadyExistsException.class)
@@ -344,10 +344,10 @@ public abstract class FileSystemTestParent {
 
     @Test(expected=NoSuchPathException.class)
     public void test_createFile_nonExistingParent_throwsException() throws Exception {
-    	generateAndCreateTestDir();
-    	Path dir = testDir.resolve(generateTestDirName());
-    	Path file = dir.resolve(generateTestFileName());    	
-    	fileSystem.createFile(file);
+        generateAndCreateTestDir();
+        Path dir = testDir.resolve(generateTestDirName());
+        Path file = dir.resolve(generateTestFileName());    	
+        fileSystem.createFile(file);
     }
 
     /* TODO: Fixme!
@@ -359,20 +359,20 @@ public abstract class FileSystemTestParent {
         fileSystem.close();
         fileSystem.createFile(file0);
     }
-    */
-    
+     */
+
     @Test
     public void test_readFromFile() throws Exception {
-    
-    	Path file = locationConfig.getExistingPath();
-    	
-    	OutputReader reader = new OutputReader(fileSystem.readFromFile(file));
 
-    	reader.waitUntilFinished();
-    	
-    	// System.out.println("READ: " + reader.getResultAsString());
-    	
-    	assertEquals("Hello World\n", reader.getResultAsString());    	
+        Path file = locationConfig.getExistingPath();
+
+        OutputReader reader = new OutputReader(fileSystem.readFromFile(file));
+
+        reader.waitUntilFinished();
+
+        // System.out.println("READ: " + reader.getResultAsString());
+
+        assertEquals("Hello World\n", reader.getResultAsString());    	
     }
 
 
@@ -476,16 +476,19 @@ public abstract class FileSystemTestParent {
         byte[] data2 = "Party people!".getBytes();
         byte[] data3 = "yes | rm -rf ".getBytes();
         byte[] data4 = "Use Xenon!".getBytes();
-        Path source = createTestSubDir(testDir);
-        Path file0 = createTestFile(source, data);
-        Path testSubDir = createTestSubDir(source);
 
+        Path source = createTestSubDir(testDir);
+        createTestFile(source, data);
+
+        Path testSubDir = createTestSubDir(source);
         Path testSubDir2 = createTestSubDir(source);
-        Path file1 = createTestFile(testSubDir2,data2);
-        Path file2 = createTestFile(testSubDir,data3);
+        createTestFile(testSubDir2,data2);
+        createTestFile(testSubDir,data3);
+
         Path testSubSub = createTestSubDir(testSubDir);
-        Path file3 = createTestFile(testSubSub,data4);
-        Path target = createTestSubDir(testDir);
+        createTestFile(testSubSub,data4);
+        createTestSubDir(testDir);
+
         Iterable<PathAttributes> pa = fileSystem.list(testDir,true);
         Iterator<PathAttributes> it1 = pa.iterator();
         Iterator<PathAttributes> it2 = pa.iterator();
@@ -506,17 +509,18 @@ public abstract class FileSystemTestParent {
             if(res.contains(p)){
                 throw new XenonException(fileSystem.getAdaptorName(),"Duplicate element in listing!");
             } else {
+                System.out.println("ADDING TO LIST: " + p);
                 res.add(p);
             }
         }
         return res;
     }
 
-    private void         assertListSetEqual(Set<PathAttributes> res, Set<PathAttributes> expected){
+    private void assertListSetEqual(Set<PathAttributes> res, Set<PathAttributes> expected){
         if(!res.equals(expected)){
-            Set superfluous = new HashSet(res);
+            Set<PathAttributes> superfluous = new HashSet<>(res);
             superfluous.removeAll(expected);
-            Set missing = new HashSet(expected);
+            Set<PathAttributes> missing = new HashSet<>(expected);
             missing.removeAll(res);
             String superfluousString;
             String missingString;
@@ -589,7 +593,7 @@ public abstract class FileSystemTestParent {
         Path file2 = createTestFile(testDir, null);
         Path file3 = createTestFile(testDir, null);
         Path subDir = createTestSubDir(testDir);
-        Path irrelevantFileInSubDir = createTestFile(subDir, null);
+        createTestFile(subDir, null);
         Set<PathAttributes> expected = new HashSet<>(7);
         expected.add(fileSystem.getAttributes(file0));
         expected.add(fileSystem.getAttributes(file1));
@@ -608,6 +612,7 @@ public abstract class FileSystemTestParent {
     @Test
     public void test_list_recursive_withSubDirs_listAll() throws Exception {
         generateAndCreateTestDir();
+        
         Path file0 = createTestFile(testDir, null);
         Path file1 = createTestFile(testDir, null);
         Path file2 = createTestFile(testDir, null);
@@ -633,26 +638,37 @@ public abstract class FileSystemTestParent {
         byte[] data2 = "Party people!".getBytes();
         byte[] data3 = "yes | rm -rf ".getBytes();
         byte[] data4 = "Use Xenon!".getBytes();
+        
         generateAndCreateTestDir();
+        
         Set<PathAttributes> list = new HashSet<>();
+        
         Path source = createTestSubDir(testDir);
         list.add(fileSystem.getAttributes(source));
+        
         Path file0 = createTestFile(source, data);
         list.add(fileSystem.getAttributes(file0));
+        
         Path testSubDir = createTestSubDir(source);
         list.add(fileSystem.getAttributes(testSubDir));
 
         Path testSubDir2 = createTestSubDir(source);
         list.add(fileSystem.getAttributes(testSubDir2));
+        
         Path file1 = createTestFile(testSubDir2,data2);
         list.add(fileSystem.getAttributes(file1));
+        
         Path file2 = createTestFile(testSubDir,data3);
         list.add(fileSystem.getAttributes(file2));
+        
         Path testSubSub = createTestSubDir(testSubDir);
         list.add(fileSystem.getAttributes(testSubSub));
+        
         Path file3 = createTestFile(testSubSub,data4);
         list.add(fileSystem.getAttributes(file3));
 
+        System.out.println("DONE CREATING!");
+        
         assertListSetEqual(listSet(testDir,true), list);
     }
 
@@ -686,8 +702,8 @@ public abstract class FileSystemTestParent {
         }
 
         if (!isWithinMargin(currentTime, result.getLastModifiedTime()) && result.getLastModifiedTime() != 0) {
-                throwWrong("test_getfileAttributes", "lastModifiedTime=" + currentTime,
-                        "lastModifiedTime=" + result.getLastModifiedTime());
+            throwWrong("test_getfileAttributes", "lastModifiedTime=" + currentTime,
+                    "lastModifiedTime=" + result.getLastModifiedTime());
 
         }
         if (!isWithinMargin(currentTime, result.getCreationTime()) && result.getCreationTime() != result.getLastModifiedTime()) {
@@ -1059,7 +1075,7 @@ public abstract class FileSystemTestParent {
         generateAndCreateTestDir();
 
         Path file = createNewTestFileName(testDir);
-        OutputStream out = fileSystem.appendToFile(file);
+        fileSystem.appendToFile(file);
     }
 
     @Test(expected = InvalidPathException.class)
@@ -1067,7 +1083,7 @@ public abstract class FileSystemTestParent {
         assumeTrue(description.canAppend());
         generateAndCreateTestDir();
         Path p = createTestSubDir(testDir);
-        OutputStream out = fileSystem.appendToFile(p);
+        fileSystem.appendToFile(p);
     }
 
 
@@ -1215,14 +1231,16 @@ public abstract class FileSystemTestParent {
         generateAndCreateTestDir();
 
         Path source = createTestSubDir(testDir);
-        Path file0 = createTestFile(source, data);
+        createTestFile(source, data);
         Path testSubDir = createTestSubDir(source);
 
         Path testSubDir2 = createTestSubDir(source);
-        Path file1 = createTestFile(testSubDir2,data2);
-        Path file2 = createTestFile(testSubDir,data3);
+        createTestFile(testSubDir2,data2);
+        createTestFile(testSubDir,data3);
+        
         Path testSubSub = createTestSubDir(testSubDir);
-        Path file3 = createTestFile(testSubSub,data4);
+        createTestFile(testSubSub,data4);
+        
         Path target = createTestSubDir(testDir);
         String copyId = fileSystem.copy(source, fileSystem,target, CopyMode.CREATE, true);
         fileSystem.waitUntilDone(copyId,10000);

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/schedulers/SchedulerTestParent.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/schedulers/SchedulerTestParent.java
@@ -708,7 +708,9 @@ public abstract class SchedulerTestParent {
     	scheduler.cancelJob("");
     }
     */
-    
+
+
+    // TODO: check illegalargument exceptions
     
     
     

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/filesystems/PathAttributesImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/filesystems/PathAttributesImplementation.java
@@ -28,11 +28,11 @@ import nl.esciencecenter.xenon.filesystems.PosixFilePermission;
  * FileAttributes represents a set of attributes of a path.
  */
 public class PathAttributesImplementation implements PathAttributes {
-	
-	/** The path these attributes belong to */
-	private Path path;
-	
-	 /** Is this a directory ? */
+
+    /** The path these attributes belong to */
+    private Path path;
+
+    /** Is this a directory ? */
     private boolean isDirectory;
 
     /** Is this a regular file ? */
@@ -40,10 +40,10 @@ public class PathAttributesImplementation implements PathAttributes {
 
     /** Is this a symbolic link ? */
     private boolean isSymbolicLink;
-    
+
     /** Is this an other type of file ? */
     private boolean isOther;
-    
+
     /** Is the file executable ? */
     private boolean executable;
 
@@ -58,27 +58,27 @@ public class PathAttributesImplementation implements PathAttributes {
 
     /** The creation time of this file */
     private long creationTime;
-    
+
     /** The last access time of this file */
     private long lastAccessTime;
-    
+
     /** The last modified time of this file */
     private long lastModifiedTime;
 
     /** The size of this file */
     private long size;
-    
+
     /** The owner of this file */
     private String owner;
-    
+
     /** The group of this file */
     private String group;
-    
+
     /** The permissions of this file (POSIX only) */
     private Set<PosixFilePermission> permissions;
-    
+
     public PathAttributesImplementation() { 
-    	// EMPTY
+        // EMPTY
     }
 
     /**
@@ -88,12 +88,12 @@ public class PathAttributesImplementation implements PathAttributes {
      *   	the path these attributes belong to.
      */
     public Path getPath() {  
-		return path;
-	}
+        return path;
+    }
 
-	public void setPath(Path path) {
-		this.path = path;
-	}
+    public void setPath(Path path) {
+        this.path = path;
+    }
 
     /**
      * Does the path refer to a directory ?
@@ -102,27 +102,26 @@ public class PathAttributesImplementation implements PathAttributes {
      *          if the path refers to a directory.
      */
     public boolean isDirectory() {
-		return isDirectory;
-	}
+        return isDirectory;
+    }
 
-	public void setDirectory(boolean isDirectory) {
-		this.isDirectory = isDirectory;
-	}
+    public void setDirectory(boolean isDirectory) {
+        this.isDirectory = isDirectory;
+    }
 
-	/**
+    /**
      * Does the path refer to a regular file ?
      * 
      * @return 
      *          if the path refers to a regular file.
      */
-	public boolean isRegular() {
-		return isRegular;
-	}
+    public boolean isRegular() {
+        return isRegular;
+    }
 
-	public void setRegular(boolean isRegular) {
-		this.isRegular = isRegular;
-	}
-
+    public void setRegular(boolean isRegular) {
+        this.isRegular = isRegular;
+    }
 
     /**
      * Does the path refer to a symbolic link ?
@@ -130,13 +129,13 @@ public class PathAttributesImplementation implements PathAttributes {
      * @return 
      *          if the path refers to a symbolic link.
      */
-	public boolean isSymbolicLink() {
-		return isSymbolicLink;
-	}
+    public boolean isSymbolicLink() {
+        return isSymbolicLink;
+    }
 
-	public void setSymbolicLink(boolean isSymbolicLink) {
-		this.isSymbolicLink = isSymbolicLink;
-	}
+    public void setSymbolicLink(boolean isSymbolicLink) {
+        this.isSymbolicLink = isSymbolicLink;
+    }
 
     /**
      * Is the path not a file, link or directory ?
@@ -144,42 +143,42 @@ public class PathAttributesImplementation implements PathAttributes {
      * @return 
      *          if the path does not refer to a file, link or directory.
      */
-	public boolean isOther() {
-		return isOther;
-	}
+    public boolean isOther() {
+        return isOther;
+    }
 
-	public void setOther(boolean isOther) {
-		this.isOther = isOther;
-	}
-	
+    public void setOther(boolean isOther) {
+        this.isOther = isOther;
+    }
+
     /**
      * Does the path refer to an executable file ?
      * 
      * @return 
      *          if the path refers an executable file ?
      */
-	public boolean isExecutable() {
-		return executable;
-	}
+    public boolean isExecutable() {
+        return executable;
+    }
 
-	public void setExecutable(boolean executable) {
-		this.executable = executable;
-	}
+    public void setExecutable(boolean executable) {
+        this.executable = executable;
+    }
 
-	
-	   /**
+
+    /**
      * Does the path refer to an readable file ?
      * 
      * @return 
      *          if the path refers an readable file ?
      */
-	public boolean isReadable() {
-		return readable;
-	}
+    public boolean isReadable() {
+        return readable;
+    }
 
-	public void setReadable(boolean readable) {
-		this.readable = readable;
-	}
+    public void setReadable(boolean readable) {
+        this.readable = readable;
+    }
 
     /**
      * Does the path refer to a writable file ?
@@ -187,13 +186,13 @@ public class PathAttributesImplementation implements PathAttributes {
      * @return 
      *          if the path refers a writable file ?
      */
-	public boolean isWritable() {
-		return writable;
-	}
+    public boolean isWritable() {
+        return writable;
+    }
 
-	public void setWritable(boolean writable) {
-		this.writable = writable;
-	}
+    public void setWritable(boolean writable) {
+        this.writable = writable;
+    }
 
     /**
      * Does the path refer to an hidden file ?
@@ -201,16 +200,16 @@ public class PathAttributesImplementation implements PathAttributes {
      * @return 
      *          if the path refers an hidden file ?
      */
-	public boolean isHidden() {
-		return hidden;
-	}
+    public boolean isHidden() {
+        return hidden;
+    }
 
-	public void setHidden(boolean hidden) {
-		this.hidden = hidden;
-	}
+    public void setHidden(boolean hidden) {
+        this.hidden = hidden;
+    }
 
-	
-	/**
+
+    /**
      * Get the creation time for this file.
      * 
      * If creationTime is not supported by the adaptor, {@link #getLastModifiedTime()} will be returned instead.
@@ -218,13 +217,13 @@ public class PathAttributesImplementation implements PathAttributes {
      * @return 
      *          the creation time for this file.
      */
-	public long getCreationTime() {
-		return creationTime;
-	}
+    public long getCreationTime() {
+        return creationTime;
+    }
 
-	public void setCreationTime(long creationTime) {
-		this.creationTime = creationTime;
-	}
+    public void setCreationTime(long creationTime) {
+        this.creationTime = creationTime;
+    }
 
     /**
      * Get the last access time for this file.
@@ -234,13 +233,13 @@ public class PathAttributesImplementation implements PathAttributes {
      * @return 
      *          the last access time for this file.
      */
-	public long getLastAccessTime() {
-		return lastAccessTime;
-	}
+    public long getLastAccessTime() {
+        return lastAccessTime;
+    }
 
-	public void setLastAccessTime(long lastAccessTime) {
-		this.lastAccessTime = lastAccessTime;
-	}
+    public void setLastAccessTime(long lastAccessTime) {
+        this.lastAccessTime = lastAccessTime;
+    }
 
     /**
      * Get the last modified time for this file.
@@ -250,15 +249,15 @@ public class PathAttributesImplementation implements PathAttributes {
      * @return 
      *          the last modified time for this file.
      */
-	public long getLastModifiedTime() {
-		return lastModifiedTime;
-	}
+    public long getLastModifiedTime() {
+        return lastModifiedTime;
+    }
 
-	public void setLastModifiedTime(long lastModifiedTime) {
-		this.lastModifiedTime = lastModifiedTime;
-	}
+    public void setLastModifiedTime(long lastModifiedTime) {
+        this.lastModifiedTime = lastModifiedTime;
+    }
 
-	
+
     /**
      * Get the size of this file in bytes.
      * 
@@ -267,15 +266,15 @@ public class PathAttributesImplementation implements PathAttributes {
      * @return 
      *          the size of this file.
      */
-	public long getSize() {
-		return size;
-	}
+    public long getSize() {
+        return size;
+    }
 
-	public void setSize(long size) {
-		this.size = size;
-	}
+    public void setSize(long size) {
+        this.size = size;
+    }
 
-	
+
     /**
      * Get the owner of this file.
      * 
@@ -285,15 +284,15 @@ public class PathAttributesImplementation implements PathAttributes {
      * @throws AttributeNotSupportedException
      *          If the attribute is not supported by the adaptor.
      */
-	public String getOwner() throws AttributeNotSupportedException {
-		return owner;
-	}
+    public String getOwner() throws AttributeNotSupportedException {
+        return owner;
+    }
 
-	public void setOwner(String owner) {
-		this.owner = owner;
-	}
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
 
-	 /**
+    /**
      * Get the group of this file.
      * 
      * @return 
@@ -302,13 +301,13 @@ public class PathAttributesImplementation implements PathAttributes {
      * @throws AttributeNotSupportedException
      *          If the attribute is not supported by the adaptor.
      */
-	public String getGroup() throws AttributeNotSupportedException {
-		return group;
-	}
+    public String getGroup() throws AttributeNotSupportedException {
+        return group;
+    }
 
-	public void setGroup(String group) {
-		this.group = group;
-	}
+    public void setGroup(String group) {
+        this.group = group;
+    }
 
     /**
      * Get the permissions of this file.
@@ -319,43 +318,44 @@ public class PathAttributesImplementation implements PathAttributes {
      * @throws AttributeNotSupportedException
      *          If the attribute is not supported by the adaptor.
      */
-	public Set<PosixFilePermission> getPermissions() throws AttributeNotSupportedException {
-		return permissions;
-	}
+    public Set<PosixFilePermission> getPermissions() throws AttributeNotSupportedException {
+        return permissions;
+    }
 
-	public void setPermissions(Set<PosixFilePermission> permissions) {
-		this.permissions = permissions;
-	}   
-	
-	public String toString() { 
-		return path.getAbsolutePath();
-	}
+    public void setPermissions(Set<PosixFilePermission> permissions) {
+        this.permissions = permissions;
+    }
 
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
-		PathAttributesImplementation that = (PathAttributesImplementation) o;
-		return isDirectory == that.isDirectory &&
-				isRegular == that.isRegular &&
-				isSymbolicLink == that.isSymbolicLink &&
-				isOther == that.isOther &&
-				executable == that.executable &&
-				readable == that.readable &&
-				writable == that.writable &&
-				hidden == that.hidden &&
-				creationTime == that.creationTime &&
-				lastAccessTime == that.lastAccessTime &&
-				lastModifiedTime == that.lastModifiedTime &&
-				size == that.size &&
-				Objects.equals(path, that.path) &&
-				Objects.equals(owner, that.owner) &&
-				Objects.equals(group, that.group) &&
-				Objects.equals(permissions, that.permissions);
-	}
+    public String toString() { 
+        return path.getAbsolutePath();
+    }
 
-	@Override
-	public int hashCode() {
-		return Objects.hash(path, isDirectory, isRegular, isSymbolicLink, isOther, executable, readable, writable, hidden, creationTime, lastAccessTime, lastModifiedTime, size, owner, group, permissions);
-	}
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PathAttributesImplementation that = (PathAttributesImplementation) o;
+        return isDirectory == that.isDirectory &&
+                isRegular == that.isRegular &&
+                isSymbolicLink == that.isSymbolicLink &&
+                isOther == that.isOther &&
+                executable == that.executable &&
+                readable == that.readable &&
+                writable == that.writable &&
+                hidden == that.hidden &&
+                creationTime == that.creationTime &&
+                lastAccessTime == that.lastAccessTime &&
+                lastModifiedTime == that.lastModifiedTime &&
+                size == that.size &&
+                Objects.equals(path, that.path) &&
+                Objects.equals(owner, that.owner) &&
+                Objects.equals(group, that.group) &&
+                Objects.equals(permissions, that.permissions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(path, isDirectory, isRegular, isSymbolicLink, isOther, executable, readable, writable, 
+                hidden, creationTime, lastAccessTime, lastModifiedTime, size, owner, group, permissions);
+    }
 }

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/filesystems/PathAttributesImplementation.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/filesystems/PathAttributesImplementation.java
@@ -323,52 +323,6 @@ public class PathAttributesImplementation implements PathAttributes {
 		return permissions;
 	}
 
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
-
-		PathAttributesImplementation that = (PathAttributesImplementation) o;
-
-		if (isDirectory != that.isDirectory) return false;
-		if (isRegular != that.isRegular) return false;
-		if (isSymbolicLink != that.isSymbolicLink) return false;
-		if (isOther != that.isOther) return false;
-		if (executable != that.executable) return false;
-		if (readable != that.readable) return false;
-		if (writable != that.writable) return false;
-		if (hidden != that.hidden) return false;
-		if (creationTime != that.creationTime) return false;
-		if (lastAccessTime != that.lastAccessTime) return false;
-		if (lastModifiedTime != that.lastModifiedTime) return false;
-		if (size != that.size) return false;
-		if (!path.equals(that.path)) return false;
-		if (owner != null ? !owner.equals(that.owner) : that.owner != null) return false;
-		if (group != null ? !group.equals(that.group) : that.group != null) return false;
-		return permissions != null ? permissions.equals(that.permissions) : that.permissions == null;
-	}
-
-	@Override
-	public int hashCode() {
-		int result = path.hashCode();
-		result = 31 * result + (isDirectory ? 1 : 0);
-		result = 31 * result + (isRegular ? 1 : 0);
-		result = 31 * result + (isSymbolicLink ? 1 : 0);
-		result = 31 * result + (isOther ? 1 : 0);
-		result = 31 * result + (executable ? 1 : 0);
-		result = 31 * result + (readable ? 1 : 0);
-		result = 31 * result + (writable ? 1 : 0);
-		result = 31 * result + (hidden ? 1 : 0);
-		result = 31 * result + (int) (creationTime ^ (creationTime >>> 32));
-		result = 31 * result + (int) (lastAccessTime ^ (lastAccessTime >>> 32));
-		result = 31 * result + (int) (lastModifiedTime ^ (lastModifiedTime >>> 32));
-		result = 31 * result + (int) (size ^ (size >>> 32));
-		result = 31 * result + (owner != null ? owner.hashCode() : 0);
-		result = 31 * result + (group != null ? group.hashCode() : 0);
-		result = 31 * result + (permissions != null ? permissions.hashCode() : 0);
-		return result;
-	}
-
 	public void setPermissions(Set<PosixFilePermission> permissions) {
 		this.permissions = permissions;
 	}   

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/filesystems/ftp/FtpFileSystem.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/filesystems/ftp/FtpFileSystem.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import nl.esciencecenter.xenon.adaptors.NotConnectedException;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
 import org.apache.commons.net.ftp.FTPFileFilters;
@@ -69,7 +70,7 @@ public class FtpFileSystem extends FileSystem {
 		LOGGER.debug("close fileSystem = {}", this);
 
 		if (!isOpen()) {
-			throw new XenonException(ADAPTOR_NAME, "File system is already closed");
+			throw new NotConnectedException(ADAPTOR_NAME, "File system is already closed");
 		}
 
 		try {

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/filesystems/local/LocalFileAdaptor.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/filesystems/local/LocalFileAdaptor.java
@@ -114,4 +114,7 @@ public class LocalFileAdaptor extends FileAdaptor {
     public boolean supportsSettingPosixPermissions(){
         return true;
     }
+
+    @Override
+    public boolean isConnectionless() { return true; }
 }

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/filesystems/local/LocalFileSystem.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/filesystems/local/LocalFileSystem.java
@@ -100,7 +100,7 @@ public class LocalFileSystem extends FileSystem {
 	
 	@Override
 	public boolean exists(Path path) throws XenonException {
-		return java.nio.file.Files.exists(LocalUtil.javaPath(this, path));
+		return java.nio.file.Files.exists(LocalUtil.javaPath(this, path),java.nio.file.LinkOption.NOFOLLOW_LINKS);
 	}
 	
 	@Override
@@ -116,7 +116,7 @@ public class LocalFileSystem extends FileSystem {
     
     @Override
     public OutputStream writeToFile(Path path, long size) throws XenonException {
-		assertPathIsNotDirectory(path);
+		assertPathNotExists(path);
         try {
             return java.nio.file.Files.newOutputStream(LocalUtil.javaPath(this, path), 
             		StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/filesystems/sftp/SftpFileSystem.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/filesystems/sftp/SftpFileSystem.java
@@ -15,23 +15,6 @@
  */
 package nl.esciencecenter.xenon.adaptors.filesystems.sftp;
 
-import static nl.esciencecenter.xenon.adaptors.filesystems.sftp.SftpFileAdaptor.ADAPTOR_NAME;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.attribute.FileTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
-import org.apache.sshd.client.subsystem.sftp.SftpClient;
-import org.apache.sshd.common.subsystem.sftp.SftpConstants;
-import org.apache.sshd.common.subsystem.sftp.SftpException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import nl.esciencecenter.xenon.XenonException;
 import nl.esciencecenter.xenon.adaptors.NotConnectedException;
 import nl.esciencecenter.xenon.adaptors.XenonProperties;
@@ -47,14 +30,30 @@ import nl.esciencecenter.xenon.filesystems.Path;
 import nl.esciencecenter.xenon.filesystems.PathAlreadyExistsException;
 import nl.esciencecenter.xenon.filesystems.PathAttributes;
 import nl.esciencecenter.xenon.filesystems.PosixFilePermission;
+import org.apache.sshd.client.subsystem.sftp.SftpClient;
+import org.apache.sshd.common.subsystem.sftp.SftpConstants;
+import org.apache.sshd.common.subsystem.sftp.SftpException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static nl.esciencecenter.xenon.adaptors.filesystems.sftp.SftpFileAdaptor.ADAPTOR_NAME;
 
 public class SftpFileSystem extends FileSystem {
-	
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(SftpFileSystem.class);
-	
+
 	private final SftpClient client;
-	
-	protected SftpFileSystem(String uniqueID, String name, String location, Path entryPath, SftpClient client, 
+
+	protected SftpFileSystem(String uniqueID, String name, String location, Path entryPath, SftpClient client,
 			XenonProperties properties) {
 		super(uniqueID, name, location, entryPath, properties);
 		this.client = client;
@@ -62,7 +61,7 @@ public class SftpFileSystem extends FileSystem {
 
 	@Override
 	public void close() throws XenonException {
-		
+
 		LOGGER.debug("close fileSystem = {}", this);
 
 		try {
@@ -72,11 +71,11 @@ public class SftpFileSystem extends FileSystem {
 		}
 
 		//info.getSession().disconnect();
-		
+
 		super.close();
-		LOGGER.debug("close OK");        
+		LOGGER.debug("close OK");
 	}
-	
+
 	@Override
 	public boolean isOpen() throws XenonException {
 		return client.isOpen();
@@ -84,11 +83,11 @@ public class SftpFileSystem extends FileSystem {
 
 	@Override
 	public void rename(Path source, Path target) throws XenonException {
-		
+
 		LOGGER.debug("move source = {} target = {}", source, target);
-		
+
 		assertPathExists(source);
-		
+
 		if (areSamePaths(source, target)) {
 			return;
 		}
@@ -109,24 +108,24 @@ public class SftpFileSystem extends FileSystem {
 	public void createDirectory(Path dir) throws XenonException {
 
 		LOGGER.debug("createDirectory dir = {}", dir);
-		
+
 		assertPathNotExists(dir);
 		assertParentDirectoryExists(dir);
-		
+
 		try {
 			client.mkdir(dir.getAbsolutePath());
 		} catch (IOException e) {
 			throw new XenonException(ADAPTOR_NAME, "Failed to mkdir", e);
 		}
 
-		LOGGER.debug("createDirectory OK");        
+		LOGGER.debug("createDirectory OK");
 	}
 
 	@Override
 	public void createFile(Path file) throws XenonException {
-		
+
 		assertPathNotExists(file);
-		
+
 		LOGGER.debug("createFile path = {}", file);
 
 		OutputStream out = null;
@@ -145,7 +144,7 @@ public class SftpFileSystem extends FileSystem {
 
 		LOGGER.debug("createFile OK");
 	}
-	
+
 	@Override
 	public void createSymbolicLink(Path link, Path path) throws XenonException {
 		try {
@@ -155,17 +154,17 @@ public class SftpFileSystem extends FileSystem {
 		}
 	}
 	@Override
-	protected void deleteFile(Path file) throws XenonException { 
-		try { 
+	protected void deleteFile(Path file) throws XenonException {
+		try {
 			client.remove(file.getAbsolutePath());
 		} catch (IOException e) {
 			sftpExceptionToXenonException(e, "Cannot delete file: " + file);
 		}
 	}
-	   
+
 	@Override
-	protected void deleteDirectory(Path dir) throws XenonException { 
-		try { 
+	protected void deleteDirectory(Path dir) throws XenonException {
+		try {
 			client.rmdir(dir.getAbsolutePath());
 		} catch (IOException e) {
 			sftpExceptionToXenonException(e, "Cannot delete directory: " + dir);
@@ -189,7 +188,7 @@ public class SftpFileSystem extends FileSystem {
 
 		return result;
 	}
-	
+
 	@Override
 	public boolean exists(Path path) throws XenonException {
 
@@ -203,47 +202,47 @@ public class SftpFileSystem extends FileSystem {
 		}
 	}
 
-//	private PathAttributesPair convert(Path root, SftpClient.DirEntry e) { 
+//	private PathAttributesPair convert(Path root, SftpClient.DirEntry e) {
 //		FileAttributes attributes = convertAttributes(e.getAttributes());
 //		return new PathAttributesPair(root.resolve(e.getFilename()), attributes);
 //	}
 //
-//	
+//
 //	private List<PathAttributesPair> listDirectory(Path path) throws XenonException {
-//		
+//
 //		assertDirectoryExists(path);
 //
 //		ArrayList<PathAttributesPair> result = new ArrayList<>();
-//		
-//		try { 
-//			for (SftpClient.DirEntry e : client.readDir(path.getAbsolutePath())) { 
+//
+//		try {
+//			for (SftpClient.DirEntry e : client.readDir(path.getAbsolutePath())) {
 //				result.add(convert(path, e));
 //			}
-//		} catch (IOException e) { 
+//		} catch (IOException e) {
 //			throw new XenonException(ADAPTOR_NAME,"Failed to retrieve directory listing of " + path);
 //		}
-//		
-//		return result;		
+//
+//		return result;
 //	}
-		
+
 	@Override
 	protected List<PathAttributes> listDirectory(Path path) throws XenonException {
 
 		try {
 			assertDirectoryExists(path);
-		
+
 			ArrayList<PathAttributes> result = new ArrayList<>();
-			for (SftpClient.DirEntry f : client.readDir(path.getAbsolutePath())) { 
+			for (SftpClient.DirEntry f : client.readDir(path.getAbsolutePath())) {
 				result.add(convertAttributes(path.resolve(f.getFilename()), f.getAttributes()));
 			}
-	
+
 			return result;
 		} catch (IOException e) {
 			throw sftpExceptionToXenonException(e, "Failed to list directory " + path);
 		}
 	}
-	
-	
+
+
 //	@Override
 //	public DirectoryStream<Path> newDirectoryStream(Path dir, Filter filter) throws XenonException {
 //		LOGGER.debug("newDirectoryStream path = {} filter = <?>", dir);
@@ -261,11 +260,11 @@ public class SftpFileSystem extends FileSystem {
 		LOGGER.debug("newInputStream path = {}", path);
 
 		assertFileExists(path);
-		
+
 		InputStream in;
 
 		try {
-			in = client.read(path.getAbsolutePath());        	
+			in = client.read(path.getAbsolutePath());
 		} catch (IOException e) {
 			throw new XenonException(ADAPTOR_NAME, "Failed to open stream to read from " + path, e);
 		}
@@ -277,18 +276,18 @@ public class SftpFileSystem extends FileSystem {
 
 	@Override
 	public OutputStream writeToFile(Path path, long size) throws XenonException {
-		
+
 		assertNotNull(path);
 		assertPathNotExists(path);
 		assertParentDirectoryExists(path);
-		
+
 		try {
-			return client.write(path.getAbsolutePath(), SftpClient.OpenMode.Write, SftpClient.OpenMode.Create, SftpClient.OpenMode.Truncate);      	
+			return client.write(path.getAbsolutePath(), SftpClient.OpenMode.Write, SftpClient.OpenMode.Create, SftpClient.OpenMode.Truncate);
 		} catch (IOException e) {
 			throw new XenonException(ADAPTOR_NAME, "Failed open stream to write to: " + path, e);
 		}
 	}
-		
+
 	@Override
 	public OutputStream writeToFile(Path path) throws XenonException {
 		return writeToFile(path, -1);
@@ -299,9 +298,9 @@ public class SftpFileSystem extends FileSystem {
 
 		assertNotNull(path);
 		assertFileExists(path);
-		
+
 		try {
-			return client.write(path.getAbsolutePath(), SftpClient.OpenMode.Write, SftpClient.OpenMode.Append);      	
+			return client.write(path.getAbsolutePath(), SftpClient.OpenMode.Write, SftpClient.OpenMode.Append);
 		} catch (IOException e) {
 			throw new XenonException(ADAPTOR_NAME, "Failed open stream to write to: " + path, e);
 		}
@@ -322,7 +321,7 @@ public class SftpFileSystem extends FileSystem {
 		try {
 			String target = client.readLink(link.getAbsolutePath());
 
-			if (!target.startsWith(File.separator)) {                
+			if (!target.startsWith(File.separator)) {
 				Path parent = link.getParent();
 				result = parent.resolve(target);
 			} else {
@@ -347,8 +346,8 @@ public class SftpFileSystem extends FileSystem {
 		}
 
 		try {
-			// We need to create a new Attributes object here. SFTP will only forward the fields that are actually set 
-			// when we call setStat. If we retrieve the existing attributes, change permissions and send the lot back 
+			// We need to create a new Attributes object here. SFTP will only forward the fields that are actually set
+			// when we call setStat. If we retrieve the existing attributes, change permissions and send the lot back
 			// we'll receive an error since some of the other attributes cannot be changed (learned this the hard way).
 			SftpClient.Attributes a = new SftpClient.Attributes();
 			a.setPermissions(PosixFileUtils.permissionsToBits(permissions));
@@ -358,16 +357,16 @@ public class SftpFileSystem extends FileSystem {
 		}
 		LOGGER.debug("setPosixFilePermissions OK");
 	}
-	
-	private static long convertTime(FileTime time) { 
+
+	private static long convertTime(FileTime time) {
 
 		return time.toMillis();
 	}
-	
-	private static PathAttributes convertAttributes(Path path, SftpClient.Attributes attributes) { 
-		
+
+	private static PathAttributes convertAttributes(Path path, SftpClient.Attributes attributes) {
+
 		PathAttributesImplementation result = new PathAttributesImplementation();
-		
+
 		result.setPath(path);
 		result.setDirectory(attributes.isDirectory());
 		result.setRegular(attributes.isRegularFile());
@@ -390,26 +389,26 @@ public class SftpFileSystem extends FileSystem {
 		}
 
 		result.setSize(attributes.getSize());
-		
+
 		Set<PosixFilePermission> permission = PosixFileUtils.bitsToPermissions(attributes.getPermissions());
 		result.setPermissions(permission);
-		
+
 		result.setExecutable(permission.contains(PosixFilePermission.OWNER_EXECUTE));
 		result.setReadable(permission.contains(PosixFilePermission.OWNER_READ));
 		result.setWritable(permission.contains(PosixFilePermission.OWNER_WRITE));
-		
+
 		result.setGroup(attributes.getGroup());
 		result.setOwner(attributes.getOwner());
-		
+
 		return result;
 	}
-	
-	
+
+
 	private static XenonException sftpExceptionToXenonException(IOException e, String message) {
 
-		if (e instanceof SftpException) { 
+		if (e instanceof SftpException) {
 			SftpException x = (SftpException) e;
-			switch (x.getStatus()) { 
+			switch (x.getStatus()) {
 
 			case SftpConstants.SSH_FX_EOF:
 				return new EndOfFileException(ADAPTOR_NAME, "Unexpected EOF", e);
@@ -493,9 +492,12 @@ public class SftpFileSystem extends FileSystem {
 
 			}
 
-			// Fall through if we do not know the error
-		} 
 
+		}
+		if (e.getMessage().contains("client is close")) {
+			return new NotConnectedException(ADAPTOR_NAME, e.getMessage());
+		}
+		// Fall through if we do not know the error
 		return new XenonException(ADAPTOR_NAME, message, e);
 	}
 }

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/filesystems/sftp/SftpFileSystem.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/filesystems/sftp/SftpFileSystem.java
@@ -279,8 +279,8 @@ public class SftpFileSystem extends FileSystem {
 	public OutputStream writeToFile(Path path, long size) throws XenonException {
 		
 		assertNotNull(path);
+		assertPathNotExists(path);
 		assertParentDirectoryExists(path);
-		assertPathIsNotDirectory(path);
 		
 		try {
 			return client.write(path.getAbsolutePath(), SftpClient.OpenMode.Write, SftpClient.OpenMode.Create, SftpClient.OpenMode.Truncate);      	

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/schedulers/slurm/SlurmScheduler.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/schedulers/slurm/SlurmScheduler.java
@@ -164,10 +164,10 @@ public class SlurmScheduler extends ScriptingScheduler {
 
     private String findInteractiveJobInMap(Map<String, Map<String, String>> queueInfo, String tag, String interactiveJobID) {
 
-        //find job with "tag" as a comment in the job info
+        //find job with "tag" as a job name in the job info. NAME is produced by squeue, JobName by sacct
         for (Map.Entry<String, Map<String, String>> entry : queueInfo.entrySet()) {
-            if (entry.getValue().containsKey("COMMENT") && entry.getValue().get("COMMENT").equals(tag) ||
-                entry.getValue().containsKey("Comment") && entry.getValue().get("Comment").equals(tag)) {
+            if (entry.getValue().containsKey("NAME") && entry.getValue().get("NAME").equals(tag) ||
+                entry.getValue().containsKey("JobName") && entry.getValue().get("JobName").equals(tag)) {
 
                 String jobID = entry.getKey();
 

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/schedulers/slurm/SlurmUtils.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/schedulers/slurm/SlurmUtils.java
@@ -334,7 +334,7 @@ public final class SlurmUtils {
         arguments.add("--quiet");
 
         //add a tag so we can find the job back in the queue later
-        arguments.add("--comment=" + tag.toString());
+        arguments.add("--job-name=" + tag.toString());
         
         //set working directory
         if (description.getWorkingDirectory() != null) {

--- a/src/main/java/nl/esciencecenter/xenon/filesystems/CopyStatus.java
+++ b/src/main/java/nl/esciencecenter/xenon/filesystems/CopyStatus.java
@@ -25,25 +25,24 @@ public interface CopyStatus {
 
 	/**
 	 * Get the copy identifier for which this CopyStatus was created.
-	 * 
+	 *
 	 * @return the Copy.
 	 */
 	String getCopyIdentifier();
 
 	/**
 	 * Get the state of the Copy operation.
-	 * 
+	 *
 	 * @return the state of the Copy operation.
 	 */
 	String getState();
 
 	/**
 	 * Get the exception produced by the Copy or while retrieving the status.
-	 * 
+	 *
 	 * @return the exception.
 	 */
-	Throwable getException();
-
+	XenonException getException();
 
 	/**
 	 * Throws the exception that occured during copying, if it exists. Otherwise continue.
@@ -63,35 +62,35 @@ public interface CopyStatus {
 
 	/**
 	 * Is the Copy still running?
-	 * 
+	 *
 	 * @return if the Copy is running.
 	 */
 	boolean isRunning();
 
 	/**
 	 * Is the Copy done?
-	 * 
+	 *
 	 * @return if the Copy is done.
 	 */
 	boolean isDone();
 
 	/**
 	 * Has the Copy or status retrieval produced a exception ?
-	 * 
+	 *
 	 * @return if the Copy or status retrieval produced a exception.
 	 */
 	boolean hasException();
 
 	/**
 	 * Get the number of bytes that need to be copied for the entire copy operation.
-	 * 
+	 *
 	 * @return the number of bytes that need to be copied.
 	 */
 	long bytesToCopy();
 
 	/**
 	 * Get the number of bytes that have been copied.
-	 * 
+	 *
 	 * @return the number of bytes that have been copied.
 	 */
 	long bytesCopied();

--- a/src/main/java/nl/esciencecenter/xenon/filesystems/FileSystem.java
+++ b/src/main/java/nl/esciencecenter/xenon/filesystems/FileSystem.java
@@ -504,8 +504,9 @@ public abstract class FileSystem {
 	 *            the existing source path.
 	 * @param target
 	 *            the non existing target path.
+
 	 * @throws UnsupportedOperationException
-	 * 				If the adapter does not support renaming.
+	 * 			   If the adapter does not support renaming.
 	 * @throws NoSuchPathException
 	 *             If the source file does not exist or the target parent directory does not exist.
 	 * @throws PathAlreadyExistsException
@@ -514,6 +515,8 @@ public abstract class FileSystem {
 	 *             If file system is closed.
 	 * @throws XenonException
 	 *             If the move failed.
+     * @throws IllegalArgumentException
+     *             If one or both of the arguments are null.
 	 */
 	public abstract void rename(Path source, Path target) throws XenonException;
 
@@ -526,8 +529,12 @@ public abstract class FileSystem {
 	 * @throws PathAlreadyExistsException
 	 *             If the directory already exists or if a parent directory could not be created because a file with the same name
 	 *             already exists.
+     * @throws NotConnectedException
+     *             If file system is closed.
 	 * @throws XenonException
 	 *             If an I/O error occurred.
+     * @throws IllegalArgumentException
+     *             If one or both of the arguments are null.
 	 */
 	public void createDirectories(Path dir) throws XenonException {
 
@@ -553,13 +560,18 @@ public abstract class FileSystem {
 	 *
 	 * @param dir
 	 *            the directory to create.
-	 *
+
 	 * @throws PathAlreadyExistsException
 	 *             If the directory already exists.
 	 * @throws NoSuchPathException
 	 *             If the parent directory does not exist.
+     * @throws NotConnectedException
+     *             If file system is closed.
 	 * @throws XenonException
 	 *             If an I/O error occurred.
+     * @throws IllegalArgumentException
+     *             If the argument is null.
+     *
 	 */
 	public abstract void createDirectory(Path dir) throws XenonException;
 
@@ -575,8 +587,12 @@ public abstract class FileSystem {
 	 *             If the file already exists.
 	 * @throws NoSuchPathException
 	 *             If the parent directory does not exist.
+     * @throws NotConnectedException
+     *             If file system is closed.
 	 * @throws XenonException
 	 *             If an I/O error occurred.
+     * @throws IllegalArgumentException
+     *             If one or both of the arguments are null.
 	 */
 	public abstract void createFile(Path file) throws XenonException;
 
@@ -594,15 +610,15 @@ public abstract class FileSystem {
 	 *             If the target or parent directory of link does not exist
 	 * @throws InvalidPathException
 	 * 			   If parent of link is not a directory
+     * @throws NotConnectedException
+     *             If file system is closed.
 	 * @throws XenonException
 	 *             If an I/O error occurred.
+     * @throws IllegalArgumentException
+     *             If one or both of the arguments are null.
 	 */
 	public abstract void createSymbolicLink(Path link, Path target) throws XenonException;
 
-	// assumes directory exists
-//	boolean isDirectoryEmpty(Path dir) throws XenonException{
-//		return !list(dir,false).iterator().hasNext();
-//	}
 
 	/**
 	 * Deletes an existing path.
@@ -618,13 +634,15 @@ public abstract class FileSystem {
 	 * @param recursive
 	 * 			if the delete must be done recursively
 	 * @throws DirectoryNotEmptyException
-	 * 		if the directory was not empty.
-	 * @throws InvalidPathException
-	 * 		if the provided path is invalid.
+	 * 		if the directory was not empty (and the delete was not recursive).
 	 * @throws NoSuchPathException
 	 * 		if the provided path does not exist.
+     * @throws NotConnectedException
+     *             If file system is closed.
 	 * @throws XenonException
 	 *          if an I/O error occurred.
+     * @throws IllegalArgumentException
+     *             If path is null.
 	 */
 	public void delete(Path path, boolean recursive) throws XenonException {
 
@@ -671,8 +689,12 @@ public abstract class FileSystem {
 	 *
 	 * @return If the path exists.
 	 *
-	 * @throws XenonException
-	 *             If an I/O error occurred.
+     * @throws NotConnectedException
+     *             If file system is closed.
+     * @throws XenonException
+     *          if an I/O error occurred.
+     * @throws IllegalArgumentException
+     *             If path is null.
 	 */
 	public abstract boolean exists(Path path) throws XenonException;
 
@@ -681,6 +703,8 @@ public abstract class FileSystem {
 	 *
 	 * All entries in the directory are returned, but subdirectories will not be traversed by default.
 	 * Set <code>recursive</code> to <code>true</code>, include the listing of all subdirectories.
+     *
+     * Symbolic links are not followed.
 	 *
 	 * @param dir
 	 *            the target directory.
@@ -693,8 +717,12 @@ public abstract class FileSystem {
 	 *             If a directory does not exists.
 	 * @throws InvalidPathException
 	 *             If <code>dir</code> is not a directory.
-	 * @throws XenonException
-	 *             If an I/O error occurred.
+     * @throws NotConnectedException
+     *             If file system is closed.
+     * @throws XenonException
+     *          if an I/O error occurred.
+     * @throws IllegalArgumentException
+     *             If path is null.
 	 */
 	public Iterable<PathAttributes> list(Path dir, boolean recursive) throws XenonException {
 		
@@ -717,16 +745,19 @@ public abstract class FileSystem {
 	 *             If the file does not exists.
 	 * @throws InvalidPathException
 	 *             If the file is not regular file.
-	 * @throws XenonException
-	 *             If an I/O error occurred.
+     * @throws NotConnectedException
+     *             If file system is closed.
+     * @throws XenonException
+     *          if an I/O error occurred.
+     * @throws IllegalArgumentException
+     *             If path is null.
 	 */
 	public abstract InputStream readFromFile(Path file) throws XenonException;
 
 	/**
 	 * Open a file and return an {@link OutputStream} to write to this file.
 	 * <p>
-	 * If the file already exists it will be replaced and its data will be lost.
-	 *
+
 	 * The size of the file (once all data has been written) must be specified using
 	 * the <code>size</code> parameter. This is required by some implementations
 	 * (typically blob-stores).
@@ -739,11 +770,14 @@ public abstract class FileSystem {
 	 *
 	 * @return the {@link OutputStream} to write to the file.
 	 *
-	 * @throws InvalidPathException
-	 *             If the file could not be created.
-	 *
-	 * @throws XenonException
-	 *             If an I/O error occurred.
+	 * @throws PathAlreadyExistsException
+	 *             If the target existed.
+     * @throws NotConnectedException
+     *             If file system is closed.
+     * @throws XenonException
+     *          if an I/O error occurred.
+     * @throws IllegalArgumentException
+     *             If path is null.
 	 */
 	public abstract OutputStream writeToFile(Path path, long size) throws XenonException;
 
@@ -968,6 +1002,7 @@ public abstract class FileSystem {
 				case IGNORE:
 					return;
 				case REPLACE:
+				    destinationFS.delete(destination,true);
 					// continue
 					break;
 			}

--- a/src/main/java/nl/esciencecenter/xenon/filesystems/FileSystem.java
+++ b/src/main/java/nl/esciencecenter/xenon/filesystems/FileSystem.java
@@ -92,14 +92,28 @@ public abstract class FileSystem {
         return adaptor;
     }
 
+    /**
+     * Gives a list names of the available adaptors.
+     */
     public static String [] getAdaptorNames() {
         return adaptors.keySet().toArray(new String[adaptors.size()]);
     }
 
+    /**
+     * Gives the description of adaptor with the given name.
+     *
+     * @param adaptorName
+     *            the type of file system to connect to (e.g. "sftp" or "webdav")
+     * @throws UnknownAdaptorException
+     *          If the adaptor name is absent in {@link #getAdaptorNames()}.
+     */
     public static FileSystemAdaptorDescription getAdaptorDescription(String adaptorName) throws UnknownAdaptorException {
         return getAdaptorByName(adaptorName);
     }
 
+    /**
+     * Gives a list of the descriptions of the available adaptors.
+     */
     public static FileSystemAdaptorDescription [] getAdaptorDescriptions() {
         return adaptors.values().toArray(new FileSystemAdaptorDescription[adaptors.size()]);
     }
@@ -229,6 +243,8 @@ public abstract class FileSystem {
      *
      * @throws XenonException
      *             If the creation of the FileSystem failed.
+     * @throws IllegalArgumentException
+     *             If adaptor is null.
      */
     public static FileSystem create(String adaptor, String location, Credential credential, Map<String, String> properties)
             throws XenonException {
@@ -262,9 +278,10 @@ public abstract class FileSystem {
      *             If the location was invalid.
      * @throws InvalidCredentialException
      *             If the credential is invalid to access the location.
-     *
      * @throws XenonException
      *             If the creation of the FileSystem failed.
+     * @throws IllegalArgumentException
+     *             If adaptor is null.
      */
     public static FileSystem create(String adaptor, String location, Credential credential) throws XenonException {
         return create(adaptor, location, credential, new HashMap<>(0));
@@ -298,6 +315,8 @@ public abstract class FileSystem {
      *
      * @throws XenonException
      *             If the creation of the FileSystem failed.
+     * @throws IllegalArgumentException
+     *             If adaptor is null.
      */
     public static FileSystem create(String adaptor, String location) throws XenonException {
         return create(adaptor, location, new DefaultCredential());
@@ -332,6 +351,8 @@ public abstract class FileSystem {
      *
      * @throws XenonException
      *             If the creation of the FileSystem failed.
+     * @throws IllegalArgumentException
+     *             If adaptor is null.
      */
     public static FileSystem create(String adaptor) throws XenonException {
         return create(adaptor, null);
@@ -468,7 +489,7 @@ public abstract class FileSystem {
 	}
 
 	/**
-	 * Close this FileSystem.
+	 * Close this FileSystem. If the adaptor does not support closing this is a no-op.
 	 *
 	 * @throws XenonException
 	 *             If the FileSystem failed to close or if an I/O error occurred.
@@ -482,7 +503,7 @@ public abstract class FileSystem {
 	}
 
 	/**
-	 * Return if the connection to the FileSystem is open.
+	 * Return if the connection to the FileSystem is open. An adaptor which does not support closing is always open.
 	 *
 	 * @throws XenonException
 	 *          if the test failed or an I/O error occurred.

--- a/src/main/java/nl/esciencecenter/xenon/filesystems/FileSystem.java
+++ b/src/main/java/nl/esciencecenter/xenon/filesystems/FileSystem.java
@@ -100,7 +100,7 @@ public abstract class FileSystem {
     }
 
     /**
-     * Gives the description of adaptor with the given name.
+     * Gives the description of the adaptor with the given name.
      *
      * @param adaptorName
      *            the type of file system to connect to (e.g. "sftp" or "webdav")

--- a/src/main/java/nl/esciencecenter/xenon/filesystems/FileSystem.java
+++ b/src/main/java/nl/esciencecenter/xenon/filesystems/FileSystem.java
@@ -1443,7 +1443,12 @@ public abstract class FileSystem {
 		} catch (TimeoutException e) {
 			state = "RUNNING";
 		} catch (ExecutionException ee) {
-			ex = new XenonException(getAdaptorName(), ee.getMessage(),ee);
+		    Throwable cause = ee.getCause();
+		    if (cause instanceof XenonException) {
+		        ex = (XenonException) cause;
+            } else {
+                ex = new XenonException(getAdaptorName(), cause.getMessage(), cause);
+            }
 			state = "FAILED";
 		} catch (CancellationException | InterruptedException ec) {
 			ex = new CopyCancelledException(getAdaptorName(), "Copy cancelled by user");

--- a/src/main/java/nl/esciencecenter/xenon/schedulers/Scheduler.java
+++ b/src/main/java/nl/esciencecenter/xenon/schedulers/Scheduler.java
@@ -26,6 +26,7 @@ import nl.esciencecenter.xenon.InvalidLocationException;
 import nl.esciencecenter.xenon.InvalidPropertyException;
 import nl.esciencecenter.xenon.UnknownPropertyException;
 import nl.esciencecenter.xenon.XenonException;
+import nl.esciencecenter.xenon.adaptors.NotConnectedException;
 import nl.esciencecenter.xenon.adaptors.XenonProperties;
 import nl.esciencecenter.xenon.adaptors.schedulers.JobStatusImplementation;
 import nl.esciencecenter.xenon.adaptors.schedulers.SchedulerAdaptor;
@@ -78,14 +79,28 @@ public abstract class Scheduler {
 		return adaptor;
 	}
 
+    /**
+     * Gives a list names of the available adaptors.
+     */
 	public static String [] getAdaptorNames() {
 		return adaptors.keySet().toArray(new String[adaptors.size()]);
 	}
 
+    /**
+     * Gives the description of the adaptor with the given name.
+     *
+     * @param adaptorName
+     *            the type of scheduler to connect to (e.g. "slurm" or "torque")
+     * @throws UnknownAdaptorException
+     *          If the adaptor name is absent in {@link #getAdaptorNames()}.
+     */
 	public static SchedulerAdaptorDescription getAdaptorDescription(String adaptorName) throws UnknownAdaptorException {
 		return getAdaptorByName(adaptorName);
 	}
 
+    /**
+     * Gives a list of the descriptions of the available adaptors.
+     */
 	public static SchedulerAdaptorDescription [] getAdaptorDescriptions() {
 		return adaptors.values().toArray(new SchedulerAdaptorDescription[adaptors.size()]);
 	}
@@ -121,6 +136,8 @@ public abstract class Scheduler {
      * 
      * @throws XenonException
      *             If the creation of the Scheduler failed.
+     * @throws IllegalArgumentException
+     *             If adaptor is null.
      */
 	public static Scheduler create(String adaptor, String location, Credential credential, Map<String, String> properties) 
             throws XenonException {
@@ -155,6 +172,8 @@ public abstract class Scheduler {
      * 
      * @throws XenonException
      *             If the creation of the Scheduler failed.
+     * @throws IllegalArgumentException
+     *             If adaptor is null.
      */
 	public static Scheduler create(String adaptor, String location, Credential credential) throws XenonException {
 		return create(adaptor, location, credential, new HashMap<>(0));
@@ -186,6 +205,8 @@ public abstract class Scheduler {
      * 
      * @throws XenonException
      *             If the creation of the Scheduler failed.
+     * @throws IllegalArgumentException
+     *             If adaptor is null.
      */
 	public static Scheduler create(String adaptor, String location) throws XenonException {
 		return create(adaptor, location, new DefaultCredential());
@@ -218,6 +239,8 @@ public abstract class Scheduler {
      * 
      * @throws XenonException
      *             If the creation of the Scheduler failed.
+     * @throws IllegalArgumentException
+     *             If adaptor is null.
      */
 	public static Scheduler create(String adaptor) throws XenonException {
 		return create(adaptor, null);
@@ -279,7 +302,9 @@ public abstract class Scheduler {
      * Get the queue names supported by this Scheduler.
      * 
      * @return the queue names supported by this Scheduler.
-     * 
+     *
+     * @throws NotConnectedException
+     *             If scheduler is closed.
      * @throws XenonException
      * 		       If an I/O error occurred.
      */
@@ -308,7 +333,9 @@ public abstract class Scheduler {
      * Get the name of the default queue.
      * 
      * @return the name of the default queue for this scheduler, or <code>null</code> if no default queue is available.
-     * 
+     *
+     * @throws NotConnectedException
+     *             If scheduler is closed.
      * @throws XenonException
      *             If an I/O error occurred.
      */
@@ -325,7 +352,10 @@ public abstract class Scheduler {
      *            the names of the queues.
      * 
      * @return an array containing the resulting job identifiers .
-     * 
+     *
+     *
+     * @throws NotConnectedException
+     *             If scheduler is closed.
      * @throws NoSuchQueueException
      *             If the queue does not exist in the scheduler.
      * @throws XenonException

--- a/src/test/java/nl/esciencecenter/xenon/filesystems/CopyStatusTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/filesystems/CopyStatusTest.java
@@ -15,12 +15,12 @@
  */
 package nl.esciencecenter.xenon.filesystems;
 
+import nl.esciencecenter.xenon.XenonException;
+import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-
-import nl.esciencecenter.xenon.XenonException;
-import org.junit.Test;
 
 public class CopyStatusTest {
 
@@ -29,31 +29,31 @@ public class CopyStatusTest {
 		CopyStatus s = new FileSystem.CopyStatusImplementation("ID", "TEST_STATE", 42, 31, null);
 		assertEquals("ID", s.getCopyIdentifier());
 	}
-	
+
 	@Test
 	public void test_getState() {
 		CopyStatus s = new FileSystem.CopyStatusImplementation("ID", "TEST_STATE", 42, 31, null);
 		assertEquals("TEST_STATE", s.getState());
 	}
-	
+
 	@Test
 	public void test_bytesToCopy() {
 		CopyStatus s = new FileSystem.CopyStatusImplementation("ID", "TEST_STATE", 42, 31, null);
 		assertEquals(42, s.bytesToCopy());
 	}
-	
+
 	@Test
 	public void test_bytesCopied() {
 		CopyStatus s = new FileSystem.CopyStatusImplementation("ID", "TEST_STATE", 42, 31, null);
 		assertEquals(31, s.bytesCopied());
 	}
-	
+
 	@Test
 	public void test_hasException_null_false() {
 		CopyStatus s = new FileSystem.CopyStatusImplementation("ID", "TEST_STATE", 42, 31, null);
 		assertFalse(s.hasException());
 	}
-	
+
 	@Test
 	public void test_hasException2_filled_true() {
 		CopyStatus s = new FileSystem.CopyStatusImplementation("ID", "TEST_STATE", 42, 31, new XenonException("file", "Something went wrong"));
@@ -63,8 +63,7 @@ public class CopyStatusTest {
 	@Test
 	public void test_getException() {
 		CopyStatus s = new FileSystem.CopyStatusImplementation("ID", "TEST_STATE", 42, 31, new XenonException("file", "Something went wrong"));
-		XenonException expected = new XenonException("file", "Something went wrong");
-		assertEquals(expected, s.getException());
+		assertEquals("file adaptor: Something went wrong", s.getException().getMessage());
 	}
 
 	@Test( expected = XenonException.class)
@@ -103,17 +102,17 @@ public class CopyStatusTest {
 		CopyStatus s = new FileSystem.CopyStatusImplementation("ID", "FAILED", 42, 31, null);
 		assertTrue(s.isDone());
 	}
-	
+
 	@Test
 	public void test_toString() {
 		String state = "STATE";
 		XenonException e = new XenonException("file", "Something went wrong");
 		long bytesToCopy = 42;
 		long bytesCopied = 3;
-		
-		String expected = "CopyStatus [copyIdentifier=ID" + ", state=" + state + ", exception=" + e + 
+
+		String expected = "CopyStatus [copyIdentifier=ID" + ", state=" + state + ", exception=" + e +
 				", bytesToCopy=" + bytesToCopy + ", bytesCopied=" + bytesCopied + "]";
-		
+
 		CopyStatus s = new FileSystem.CopyStatusImplementation("ID", state, bytesToCopy, bytesCopied, e);
 		assertEquals(expected, s.toString());
 	}

--- a/src/test/java/nl/esciencecenter/xenon/filesystems/CopyStatusTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/filesystems/CopyStatusTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import nl.esciencecenter.xenon.XenonException;
 import org.junit.Test;
 
 public class CopyStatusTest {
@@ -48,17 +49,30 @@ public class CopyStatusTest {
 	}
 	
 	@Test
-	public void test_hasException1() {
+	public void test_hasException_null_false() {
 		CopyStatus s = new FileSystem.CopyStatusImplementation("ID", "TEST_STATE", 42, 31, null);
 		assertFalse(s.hasException());
 	}
 	
 	@Test
-	public void test_hasException2() {
-		CopyStatus s = new FileSystem.CopyStatusImplementation("ID", "TEST_STATE", 42, 31, new Exception());
+	public void test_hasException2_filled_true() {
+		CopyStatus s = new FileSystem.CopyStatusImplementation("ID", "TEST_STATE", 42, 31, new XenonException("file", "Something went wrong"));
 		assertTrue(s.hasException());
 	}
-	
+
+	@Test
+	public void test_getException() {
+		CopyStatus s = new FileSystem.CopyStatusImplementation("ID", "TEST_STATE", 42, 31, new XenonException("file", "Something went wrong"));
+		XenonException expected = new XenonException("file", "Something went wrong");
+		assertEquals(expected, s.getException());
+	}
+
+	@Test( expected = XenonException.class)
+	public void test_maybeThrowException() throws XenonException {
+		CopyStatus s = new FileSystem.CopyStatusImplementation("ID", "TEST_STATE", 42, 31, new XenonException("file", "Something went wrong"));
+		s.maybeThrowException();
+	}
+
 	@Test
 	public void test_isRunning1() {
 		CopyStatus s = new FileSystem.CopyStatusImplementation("ID", "TEST_STATE", 42, 31, null);
@@ -93,7 +107,7 @@ public class CopyStatusTest {
 	@Test
 	public void test_toString() {
 		String state = "STATE";
-		Exception e = new Exception("OOPS");
+		XenonException e = new XenonException("file", "Something went wrong");
 		long bytesToCopy = 42;
 		long bytesCopied = 3;
 		
@@ -103,8 +117,4 @@ public class CopyStatusTest {
 		CopyStatus s = new FileSystem.CopyStatusImplementation("ID", state, bytesToCopy, bytesCopied, e);
 		assertEquals(expected, s.toString());
 	}
-
-			
-
-	
 }

--- a/src/test/java/nl/esciencecenter/xenon/filesystems/FileSystemTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/filesystems/FileSystemTest.java
@@ -15,11 +15,6 @@
  */
 package nl.esciencecenter.xenon.filesystems;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -37,6 +32,9 @@ import nl.esciencecenter.xenon.adaptors.filesystems.PathAttributesImplementation
 import nl.esciencecenter.xenon.adaptors.filesystems.local.LocalFileAdaptor;
 
 import org.junit.Test;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.*;
 
 public class FileSystemTest {
 
@@ -997,7 +995,7 @@ public class FileSystemTest {
 
 		assertTrue(s.isDone());
 		assertTrue(s.hasException());
-		assertTrue(s.getException() instanceof PathAlreadyExistsException);
+		assertThat(s.getException(), instanceOf(PathAlreadyExistsException.class));
 	}
 
 	@Test
@@ -1066,7 +1064,7 @@ public class FileSystemTest {
 
 		assertTrue(s.isDone());
 		assertTrue(s.hasException());
-		assertTrue(s.getException() instanceof NoSuchPathException);
+		assertThat(s.getException(), instanceOf(NoSuchPathException.class));
 	}
 
 	@Test
@@ -1083,7 +1081,7 @@ public class FileSystemTest {
 
 		assertTrue(s.isDone());
 		assertTrue(s.hasException());
-		assertTrue(s.getException() instanceof InvalidPathException);
+		assertThat(s.getException(), instanceOf(InvalidPathException.class));
 	}
 
 	@Test
@@ -1106,7 +1104,7 @@ public class FileSystemTest {
 
 		assertTrue(s.isDone());
 		assertTrue(s.hasException());
-		assertTrue(s.getException() instanceof InvalidPathException);
+		assertThat(s.getException(), instanceOf(InvalidPathException.class));
 	}
 
 	@Test
@@ -1209,7 +1207,7 @@ public class FileSystemTest {
 
 		assertTrue(s2.isDone());
 		assertTrue(s2.hasException());
-		assertTrue(s2.getException() instanceof XenonException);
+		assertThat(s2.getException(), instanceOf(XenonException.class));
 	}
 
 	private void sleep(long delay) { 


### PR DESCRIPTION
We made the exceptions in the public Filesystem API in the documentation, implementation and tests consistent and more specific.

This lead to some small API additions, namely:
    
*    A function maybeThrowException in CopyStatus.
*    WriteToFile now fails if path already exists.
*    CopyStatus now contains a XenonException instead of a Throwable.

