### PR TITLE
Added keySet() and getDefault() methods to CredentialMap

### DIFF
--- a/src/main/java/nl/esciencecenter/xenon/credentials/CredentialMap.java
+++ b/src/main/java/nl/esciencecenter/xenon/credentials/CredentialMap.java
@@ -16,6 +16,7 @@
 package nl.esciencecenter.xenon.credentials;
 
 import java.util.HashMap;
+import java.util.Set;
 
 /**
  * A {@link Credential} consisting of a collection of Credentials each uniquely identified by a String (typically a host name or host alias).
@@ -94,6 +95,24 @@ public class CredentialMap implements Credential {
         return defaultCredential;
     }
 
+    /**
+     * Returns a {@link Set} view of the keys contained in this map.
+     *
+     * @return a set view of the keys contained in this map
+     */
+    public Set<String> keySet() {
+        return map.keySet();
+    }
+
+    /**
+     * Returns the default {@link UserCredential}.
+     *
+     * @return the default credential to return by <code>get</code> if a key is not found.
+     */
+    public UserCredential getDefault() {
+        return defaultCredential;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -124,5 +143,4 @@ public class CredentialMap implements Credential {
 
         return map.equals(other.map);
     }
-
 }

--- a/src/test/java/nl/esciencecenter/xenon/credentials/CredentialMapTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/credentials/CredentialMapTest.java
@@ -20,6 +20,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.Test;
 
 public class CredentialMapTest {
@@ -153,4 +156,35 @@ public class CredentialMapTest {
         assertFalse(m.equals(m2));
     }
 
+    @Test
+    public void test_keySet() {
+        CredentialMap m = new CredentialMap();
+        PasswordCredential p = new PasswordCredential("test", "foo".toCharArray());
+        m.put("key", p);
+
+        Set<String>ks = m.keySet();
+
+        Set<String> expected = new HashSet<>();
+        expected.add("key");
+        assertEquals(expected, ks);
+    }
+
+    @Test
+    public void test_getDefault_noDefault_null() {
+        CredentialMap m = new CredentialMap();
+
+        UserCredential d = m.getDefault();
+
+        assertNull(d);
+    }
+
+    @Test
+    public void test_getDefault_Password() {
+        PasswordCredential p = new PasswordCredential("test", "foo".toCharArray());
+        CredentialMap m = new CredentialMap(p);
+
+        UserCredential d = m.getDefault();
+
+        assertEquals(p, d);
+    }
 }


### PR DESCRIPTION
Required for xenon-grpc to map CredentialMap to a grpc message.

Fixes #589