### PR TITLE
added a .zenodo.json file to control metadata on Zenodo

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,69 @@
+{
+    "description": "A middleware abstraction library that provides a simple programming interface to various compute and storage resources.",
+    "license": "Apache-2.0",
+    "title": "Xenon",
+    "upload_type": "software",
+    "creators": [{
+            "affiliation": "Netherlands eScience Center",
+            "name": "Maassen, Jason"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Verhoeven, Stefan"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Borgdorff, Joris"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Spaaks, Jurriaan H."
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Drost, Niels"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Meijer, Christiaan"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "van der Ploeg, Atze"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "de Boer, Piter T."
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "van Nieuwpoort, Rob"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "van Werkhoven, Ben"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Kuzniar, Arnold",
+            "orcid": "0000-0003-1711-7961"
+        }
+    ],
+    "access_right": "open",
+    "keywords": [
+        "Java",
+        "batch-job",
+        "middleware",
+        "library",
+        "FTP",
+        "S3",
+        "SFTP",
+        "WebDAV",
+        "HDFS",
+        "SGE",
+        "SLURM",
+        "SSH",
+        "Torque",
+        "distributed computing"
+    ]
+}


### PR DESCRIPTION
Hey I'm experimenting a bit with controlling the metadata that gets attached to your releases on Zenodo. In this PR, I've added a new file ``.zenodo.json`` which now includes the contributors from https://github.com/NLeSC/Xenon/graphs/contributors as ``creators``. If you also want to include people who make issues and such, there is another field ``contributors`` you can add to the ``.zenodo.json``. Items you include there can have an attribute ``type`` which you can set to ``Other`` or another type from the controlled vocabulary [ContactPerson, DataCollector, DataCurator, DataManager, Editor, Researcher, RightsHolder, Sponsor, Other]. 

Anyway long story short, with this ``.zenodo.json`` file, your release process should be less painful.
-Jurriaan